### PR TITLE
chore: forbid(unsafe_code) at the zenanalyze crate root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,14 @@ name = "tier1_bench"
 required-features = ["experimental", "composites"]
 
 [lints.rust]
-unsafe_code = "allow"
+# zenanalyze ships zero `unsafe` blocks; SIMD goes through the
+# safe-token wrappers in archmage / magetypes. Forbidding here
+# keeps the door shut against well-meaning PRs that want to drop
+# raw `_mm_*` / `vld*` intrinsics into hot loops (see closed #17
+# for the recent example). If a future kernel genuinely needs an
+# intrinsic that magetypes hasn't wrapped yet, the right play is
+# to upstream the wrapper, not relax this lint.
+unsafe_code = "forbid"
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(feature, values("avx512", "optimized-tables"))',
 ] }


### PR DESCRIPTION
zenanalyze ships zero \`unsafe\` blocks today; all SIMD goes through magetypes / archmage safe-token wrappers. The lint was set to \`allow\` with a stale "intentional unsafe for performance-critical code" comment from before the SIMD migration.

Flipping to \`forbid\` keeps the door closed against future PRs that want to drop raw \`_mm_*\` / \`vld*\` intrinsics into hot loops — the recently-closed [#17](https://github.com/imazen/zenanalyze/pull/17) used 17 sites of raw intrinsics instead of the magetypes pattern. The right play when a kernel needs an intrinsic magetypes hasn't wrapped yet is to upstream the wrapper, not relax this lint.

\`zenpicker\` (sibling in this workspace) already enforces \`#![forbid(unsafe_code)]\`. Aligning here makes the workspace-wide rule self-consistent.

## Test plan

- [x] \`cargo build --features experimental,composites\` clean
- [x] \`cargo test --features experimental,composites --lib\` — 140/140 pass (skipped \`large_image_completes_in_reasonable_time_with_default_budget\` for local turnaround; CI will run it)
- [ ] CI matrix — will run on push