### PR TITLE
feat(zenpicker): training pipeline canonicalized at zenpicker/tools/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Cargo.lock
 /tmp_*
 *.log
 .DS_Store
+__pycache__/

--- a/zenpicker/README.md
+++ b/zenpicker/README.md
@@ -14,13 +14,15 @@ This README is the canonical entry point — every concept (workflow, output lay
 | **[FOR_NEW_CODECS.md](FOR_NEW_CODECS.md)** | Tutorial. Walk a new codec from "I have a config grid" to a shipped bake in ~30 min. Skip if you've integrated a codec before |
 | **[SAFETY_PLANE.md](SAFETY_PLANE.md)** | Codec-implementation deep dive. Two-shot rescue protocol, RescuePolicy field layout, calibration questions still open |
 
-Reference code:
+Reference code + tools:
 
 | File | What it is |
 |---|---|
 | **[examples/hybrid_heads_codec_sketch.rs](examples/hybrid_heads_codec_sketch.rs)** | Runnable codec-side reference: `CELLS` table, constraint mask, `argmin_masked_in_range` + scalar clamp |
 | **[examples/load_baked_model.rs](examples/load_baked_model.rs)** | Smoke test for the loader on any bake artifact |
-| **[../tools/bake_picker.py](../tools/bake_picker.py)** | sklearn JSON → v1 binary + manifest. Codec-agnostic — codec declares `extra_axes` + `schema_version_tag` in its training output |
+| **[examples/zenjpeg_picker_config.py](examples/zenjpeg_picker_config.py)** | Reference codec config the training pipeline imports — paths, KEEP_FEATURES, ZQ_TARGETS, `parse_config_name`. New codecs copy and edit |
+| **[tools/](tools/README.md)** | Codec-agnostic training pipeline (`train_hybrid.py`, `train_distill.py`, `feature_ablation.py`, …). Each script imports `_picker_lib.py` and a codec config module — see [tools/README.md](tools/README.md) |
+| **[../tools/bake_picker.py](../tools/bake_picker.py)** | sklearn JSON → v1 binary + manifest. Codec-agnostic |
 | **[../tools/bake_roundtrip_check.py](../tools/bake_roundtrip_check.py)** | Verify Rust loader matches numpy reference forward pass |
 
 ---
@@ -48,8 +50,9 @@ zenpicker owns this. Each codec crate owns its `ConfigSpec` enumeration, constra
                 └──────────┬──────────┘
                            ↓
                 ┌─────────────────────┐
-                │  Train teacher      │  ← scripts/zq_bytes_distill.py
-                │  HistGB per-config  │     n_configs × HistGradientBoosting
+                │  Train teacher      │  ← zenpicker/tools/train_hybrid.py
+                │  HistGB per-cell    │     N cells × 3 heads, parallel via joblib
+                │  (parallel)         │     ~30 s on 16 cores
                 └──────────┬──────────┘
                            ↓
                 ┌─────────────────────┐
@@ -81,12 +84,20 @@ Per the project-wide sweep discipline (size × quality × mode × content axes; 
 
 ### Phase 2 — Train + distill
 
-`scripts/zq_bytes_distill.py` (in the codec repo) does both halves:
+The training pipeline lives at [`zenpicker/tools/`](tools/README.md) — codec-agnostic. Each codec writes a small **codec config module** declaring its TSV paths, feature subset, target_zq grid, and config-name parser; the training scripts import it via `--codec-config <module-name>`.
 
-1. **Teacher** — per-config HistGradientBoostingRegressor (max_iter=400, max_depth=8). Predicts log-bytes from the simple feature vector. Accuracy ceiling, but bakes to MB-class artifacts.
-2. **Student** — single shared MLP (`n_inputs → 64 → 64 → n_configs`) with engineered cross-terms (`zq × feat[i]`, `log_pixels`, polynomials, `icc_bytes`). Trained on the teacher's soft targets, not raw labels — closes most of the gap to the teacher.
+```bash
+PYTHONPATH=<zenanalyze>/zenpicker/examples:<zenanalyze>/zenpicker/tools \
+    python3 <zenanalyze>/zenpicker/tools/train_hybrid.py \
+        --codec-config zenjpeg_picker_config
+```
 
-Output: `benchmarks/zq_bytes_distill_<DATE>.json` carrying `n_inputs`, `n_outputs`, `feat_cols`, `scaler_mean`, `scaler_scale`, `layers[]` (each with `W` and `b`), and a `config_names` mapping for the manifest.
+Two phases inside the script:
+
+1. **Teacher** — per-cell HistGradientBoostingRegressor (max_iter=400, max_depth=8). Predicts log-bytes + per-cell scalar values from the simple feature vector. Trained in parallel via joblib (~30 s for 36 models on a 16-core box vs ~25 min serial).
+2. **Student** — single shared MLP (`n_inputs → 128 → 128 → 3*N_cells`) with engineered cross-terms (`zq × feat[i]`, `log_pixels`, polynomials, `icc_bytes`). Trained on the teacher's soft targets, not raw labels — closes most of the gap to the teacher.
+
+Output JSON carries `n_inputs`, `n_outputs`, `feat_cols`, `scaler_mean`, `scaler_scale`, `layers[]` (each with `W` and `b`), and a `hybrid_heads_manifest` declaring the categorical-vs-scalar layout. See [tools/README.md](tools/README.md) for the full file map and the codec-config contract.
 
 ### Phase 3 — Bake to binary
 

--- a/zenpicker/examples/zenjpeg_picker_config.py
+++ b/zenpicker/examples/zenjpeg_picker_config.py
@@ -1,0 +1,119 @@
+"""
+Codec config for zenjpeg's hybrid-heads picker.
+
+Used by `zenpicker/tools/train_hybrid.py` (and the other tools/
+training scripts). The codec defines:
+
+  - paths to the Pareto sweep + features TSVs and the desired
+    output JSON / log
+  - the `feat_*` column subset (KEEP_FEATURES) the picker uses
+  - the target_zq grid (ZQ_TARGETS) the picker is trained against
+  - `parse_config_name(name)` — the codec's regex / parser that
+    decomposes a config_name string into categorical + scalar axes
+
+Run training with:
+
+    cd <zenjpeg checkout>
+    PYTHONPATH=<zenanalyze>/zenpicker/examples \\
+      python3 <zenanalyze>/zenpicker/tools/train_hybrid.py \\
+        --codec-config zenjpeg_picker_config
+
+A new codec (zenwebp / zenavif / zenjxl) writes its own copy of
+this file: change paths, change feature subset, change parser
+pattern, and import the same `train_hybrid.py`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# ---------- Paths ----------
+
+# zenjpeg's pareto sweep harness produces these:
+PARETO = Path("benchmarks/zq_pareto_2026-04-29.tsv")
+FEATURES = Path("benchmarks/zq_pareto_features_2026-04-29.tsv")
+
+# Where to write the trained model + summary:
+OUT_JSON = Path("benchmarks/zq_bytes_hybrid_2026-04-29.json")
+OUT_LOG = Path("benchmarks/zq_bytes_hybrid_2026-04-29.log")
+
+
+# ---------- Schema ----------
+
+# 8-feature reduced schema (validated by zenjpeg's PR #129 ablation;
+# 11 of 19 zenanalyze features dropped including the entire Tier 2
+# chroma sliding-window pass + alpha + palette tiers). See the
+# zenpicker README's "Documentation map" → FOR_NEW_CODECS.md for
+# how the codec runs its own ablation if a different feature set
+# is preferred.
+KEEP_FEATURES = [
+    "feat_variance",
+    "feat_edge_density",
+    "feat_uniformity",
+    "feat_chroma_complexity",
+    "feat_cb_sharpness",
+    "feat_cr_sharpness",
+    "feat_high_freq_energy_ratio",
+    "feat_luma_histogram_entropy",
+]
+
+# Zq target grid: step 5 from 0..70 + step 2 from 70..100 (the
+# perceptibility threshold band where 1-2 zensim points actually
+# matter).
+ZQ_TARGETS = list(range(0, 70, 5)) + list(range(70, 101, 2))
+
+
+# ---------- Config-name parser ----------
+
+# Pattern examples from zenjpeg's `zq_pareto_calibrate.rs` harness:
+#   ycbcr_444_noT_cs60        → ycbcr 4:4:4, no trellis, no SA, chroma_scale=0.60
+#   ycbcr_444_noT_cs60_sa     → ycbcr 4:4:4, no trellis, SA on,  chroma_scale=0.60
+#   ycbcr_444_hyb80_cs60      → ycbcr 4:4:4, trellis lambda=8.0, no SA, cs=0.60
+#   ycbcr_444_hyb145_cs100_sa → ycbcr 4:4:4, lambda=14.5, SA on, cs=1.00
+#   xyb_420_hyb250_cs150      → xyb BQuarter, trellis lambda=25.0, no SA (xyb-only), cs=1.50
+#
+# `hyb<N>` encodes lambda × 10 (so hyb80=8.0, hyb145=14.5, hyb250=25.0).
+# `cs<N>` encodes chroma_scale × 100.
+
+_CONFIG_RE = re.compile(
+    r"^(?P<color>ycbcr|xyb)_(?P<sub>444|420)_"
+    r"(?:noT|hyb(?P<lam>\d+))_cs(?P<cs>\d+)(?P<sa>_sa)?$"
+)
+
+# Sentinel value for "trellis off" cells. The picker's lambda head
+# still emits a value at these cell indices; the codec ignores it
+# at inference when the categorical cell has trellis_on=False. 0.0
+# is clearly out-of-band relative to the real lambda range
+# {8.0, 14.5, 25.0}.
+LAMBDA_NOTRELLIS_SENTINEL = 0.0
+
+
+def parse_config_name(name: str) -> dict:
+    """Parse a zenjpeg config name into its categorical + scalar axes.
+
+    Returns a dict with keys:
+      - `color`, `sub`, `sa`, `trellis_on` — categorical (form cells)
+      - `lambda`, `chroma_scale`            — scalar prediction targets
+    """
+    m = _CONFIG_RE.match(name)
+    if not m:
+        raise ValueError(f"unparseable config name: {name}")
+    color = m.group("color")
+    sub = m.group("sub")
+    lam_raw = m.group("lam")
+    cs_raw = m.group("cs")
+    sa = m.group("sa") is not None
+    trellis_on = lam_raw is not None
+    lam_val = LAMBDA_NOTRELLIS_SENTINEL
+    if trellis_on:
+        lam_val = int(lam_raw) / 10.0
+    cs_val = int(cs_raw) / 100.0
+    return {
+        "color": color,
+        "sub": sub,
+        "sa": sa,
+        "trellis_on": trellis_on,
+        "lambda": lam_val,
+        "chroma_scale": cs_val,
+    }

--- a/zenpicker/tools/README.md
+++ b/zenpicker/tools/README.md
@@ -1,0 +1,104 @@
+# zenpicker training pipeline
+
+Codec-agnostic training scripts. Each codec writes a small **codec
+config module** (see [`examples/zenjpeg_picker_config.py`](../examples/zenjpeg_picker_config.py))
+declaring its TSV paths, feature schema, zq target grid, and
+config-name parser. Then runs these scripts against that config.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `_picker_lib.py` | Shared library: disk-cached dataset construction, parallel teacher training (joblib), HISTGB_FAST/FULL presets, subsample helper, StepTimer |
+| `train_hybrid.py` | **Recommended.** Hybrid-heads training: N categorical cells + K scalar prediction heads per cell. Codec supplies the cell taxonomy via `parse_config_name` |
+| `train_distill.py` | Categorical-only distillation (legacy v1.x picker shape). Per-config HistGB teacher → small shared MLP student |
+| `train_distill_reduced.py` | Same as `train_distill.py` but with a reduced feature subset declared in the codec config |
+| `feature_ablation.py` | Single-feature LOO ablation across `KEEP_FEATURES` |
+| `feature_group_ablation.py` | Group ablation (drop entire tier-aligned groups) |
+| `validate_schema.py` | Re-train production HistGB with a chosen feature subset, report held-out metrics |
+| `capacity_sweep.py` | Architecture × cross-term-recipe sweep over the student MLP |
+
+The [`tools/bake_picker.py`](../../tools/bake_picker.py) script (parent
+directory, not this one) consumes the JSON output of any of the
+training scripts and emits the v1 binary blob + manifest.
+
+## Codec config contract
+
+A codec config module exports:
+
+```python
+from pathlib import Path
+
+PARETO        = Path(...)          # Pareto sweep TSV
+FEATURES      = Path(...)          # Analyzer features TSV
+OUT_JSON      = Path(...)          # Trained model JSON output
+OUT_LOG       = Path(...)          # Training summary text output
+KEEP_FEATURES = [...]              # list[str] of `feat_*` columns
+ZQ_TARGETS    = [...]              # list[int] of target_zq values
+
+def parse_config_name(name: str) -> dict:
+    """Parse a config_name into categorical + scalar axes."""
+    ...
+```
+
+`parse_config_name` returns a dict where keys partition into
+**categorical axes** (hashable values; combined to form cells) and
+**scalar axes** (floats; per-cell prediction targets, with a
+sentinel value for cells where the axis is N/A).
+
+For the zenjpeg reference, see [`examples/zenjpeg_picker_config.py`](../examples/zenjpeg_picker_config.py).
+
+## End-to-end
+
+```bash
+# 1. Codec runs its Pareto sweep harness, producing TSVs.
+cd zenjpeg-checkout
+cargo run --release -p zenjpeg --features 'target-zq trellis' \
+    --example zq_pareto_calibrate
+
+# 2. Train the hybrid-heads picker against zenjpeg's config taxonomy.
+PYTHONPATH=zenanalyze/zenpicker/examples:zenanalyze/zenpicker/tools \
+    python3 zenanalyze/zenpicker/tools/train_hybrid.py \
+        --codec-config zenjpeg_picker_config
+
+# 3. Bake to v1 binary.
+python3 zenanalyze/tools/bake_picker.py \
+    --model benchmarks/zq_bytes_hybrid_2026-04-29.json \
+    --out   models/zenjpeg_picker_v2.0_hybrid.bin \
+    --dtype f16
+
+# 4. Verify round-trip.
+python3 zenanalyze/tools/bake_roundtrip_check.py \
+    --model benchmarks/zq_bytes_hybrid_2026-04-29.json \
+    --dtype f16
+```
+
+End-to-end retrain on a 16-core box, with the dataset cache warm:
+~3 minutes wall-clock (was ~25 minutes before the parallel-teachers
+refactor).
+
+## Iteration vs production
+
+`_picker_lib.py` exports two HistGB hyperparameter presets:
+
+| Preset | `max_iter` | `max_depth` | When |
+|---|---:|---:|---|
+| `HISTGB_FAST` | 100 | 4 | Architecture sweeps, ablation runs, anything you'll re-run |
+| `HISTGB_FULL` | 400 | 8 | Production bake — only the final pre-bake training run |
+
+The picker ablation work confirmed feature-importance ranking is
+stable between FAST and FULL; absolute mean overhead drops by ~1pp
+when switching FAST→FULL. Use FAST for everything except the final
+bake.
+
+## Adding a new codec
+
+1. Copy `examples/zenjpeg_picker_config.py` to `examples/<your_codec>_picker_config.py`.
+2. Edit paths, KEEP_FEATURES, ZQ_TARGETS, and `parse_config_name` for your codec's config name pattern.
+3. Add `examples/` to `PYTHONPATH` and run the training scripts as above.
+
+The runtime crate (zenpicker) doesn't change. Your codec's encoder
+crate ships the produced `.bin` via `include_bytes!` and a
+compile-time `CELLS` table matching the manifest. See
+[FOR_NEW_CODECS.md](../FOR_NEW_CODECS.md) for the codec-side wiring
+walkthrough.

--- a/zenpicker/tools/_picker_lib.py
+++ b/zenpicker/tools/_picker_lib.py
@@ -1,0 +1,548 @@
+"""
+Shared helpers for the zenpicker training pipeline. Codec-agnostic:
+every codec (zenjpeg today, zenwebp / zenavif / zenjxl tomorrow)
+imports these helpers and supplies its own KEEP_FEATURES list,
+config-name parser, and Pareto TSV path. The per-codec wrapper
+script stays short (~30-50 lines).
+
+Lives at `zenanalyze/zenpicker/tools/_picker_lib.py`. Was
+previously `zenjpeg/scripts/_zq_picker_lib.py`; moved 2026-04-29
+to make the training pipeline a first-class part of zenpicker
+rather than zenjpeg-specific tooling that other codecs would have
+to fork or copy.
+
+Three big wins encapsulated:
+
+1. **Disk-cached dataset construction.** Loading the Pareto TSV +
+   Features TSV and pivoting into (X, Y, meta) takes ~30 s in pure
+   Python. After the first run we serialize to .npz and subsequent
+   loads are ~100 ms. Cache key is the TSV mtimes + the
+   `keep_features` list — invalidates correctly on any input or
+   schema change.
+
+2. **Parallel teacher training.** sklearn's HistGB is single-
+   threaded. Per-config training is embarrassingly parallel —
+   `joblib.Parallel` with `n_jobs=-1` gives ~10-16× speedup on a
+   16-core box. Drops the teacher step from 5-10 min to 30-60 s.
+   On the 12-cell hybrid-heads model: 25 min → 30 s = ~50× on the
+   teacher step alone.
+
+3. **HistGB fast/full presets.** `HISTGB_FAST` (max_iter=100,
+   max_depth=4) is the iteration default; `HISTGB_FULL`
+   (max_iter=400, max_depth=8) matches the production distill. The
+   ablation work validated that ranking is stable between them —
+   use FAST while iterating, FULL for the final bake.
+
+Per-codec wiring example (zenjpeg):
+
+    from zenpicker.tools import _picker_lib as picker
+
+    KEEP_FEATURES = [...]  # codec's chosen feature schema
+    Xs, Y, meta, _, _ = picker.load_or_build_dataset(
+        Path("benchmarks/zenjpeg_pareto.tsv"),
+        Path("benchmarks/zenjpeg_features.tsv"),
+        keep_features=KEEP_FEATURES,
+    )
+    teachers = picker.train_teachers_parallel(Xs, Y)
+    ...
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from joblib import Parallel, delayed
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+ZQ_TARGETS_DEFAULT = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC_DEFAULT = 0.20
+SEED_DEFAULT = 0xCAFE
+
+CACHE_DIR = Path("/tmp/zq_picker_cache")
+
+# Production preset — matches zq_bytes_distill.py teacher.
+HISTGB_FULL = dict(
+    max_iter=400,
+    max_depth=8,
+    learning_rate=0.05,
+    l2_regularization=0.5,
+    random_state=SEED_DEFAULT,
+)
+
+# Iteration preset — quality loss ~1 pp vs FULL but ranking stable.
+# Use this for ablation sweeps, hyperparameter searches, anything
+# you'll re-run more than twice.
+HISTGB_FAST = dict(
+    max_iter=100,
+    max_depth=4,
+    learning_rate=0.1,
+    l2_regularization=0.5,
+    random_state=SEED_DEFAULT,
+)
+
+
+# ---------- Cache key + load ----------
+
+
+def _cache_key(
+    pareto_path: Path, features_path: Path, keep_features: list[str] | None
+) -> str:
+    """Stable hash for the cache filename. Invalidates on TSV mtime
+    or KEEP_FEATURES change."""
+    h = hashlib.blake2b(digest_size=8)
+    h.update(str(pareto_path.resolve()).encode())
+    h.update(str(int(pareto_path.stat().st_mtime)).encode())
+    h.update(str(features_path.resolve()).encode())
+    h.update(str(int(features_path.stat().st_mtime)).encode())
+    if keep_features is not None:
+        for f in keep_features:
+            h.update(f.encode())
+            h.update(b"\x00")
+    return h.hexdigest()
+
+
+def load_pareto_raw(path: Path) -> tuple[dict, dict]:
+    """Slow path: parse the full Pareto TSV. Returns (rows, config_names)."""
+    rows: dict = defaultdict(list)
+    config_names: dict = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            config_names.setdefault(cid, r["config_name"])
+            key = (
+                r["image_path"],
+                r["size_class"],
+                int(r["width"]),
+                int(r["height"]),
+            )
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows, config_names
+
+
+def load_features_raw(
+    path: Path, keep_features: list[str] | None
+) -> tuple[dict, list[str]]:
+    """Slow path: parse the features TSV. Optionally restrict + reorder columns."""
+    feats: dict = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        all_cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        if keep_features is not None:
+            cols = [c for c in keep_features if c in all_cols]
+            missing = [c for c in keep_features if c not in all_cols]
+            if missing:
+                raise SystemExit(f"missing feature columns in TSV: {missing}")
+        else:
+            cols = all_cols
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in cols], dtype=np.float32
+            )
+    return feats, cols
+
+
+def build_dataset_simple(
+    pareto: dict,
+    config_names: dict,
+    feats: dict,
+    feat_cols: list[str],
+    zq_targets: list[int],
+) -> tuple[np.ndarray, np.ndarray, list[tuple]]:
+    """Build (Xs, Y, meta) where Xs is the simple input vector
+    (n_feats + 4 size onehot + log_pixels + zq_norm) and Y[i, c] is
+    log(min bytes for config c at the given image+size+zq), or NaN
+    if config c didn't reach the target on that cell.
+
+    No cross-term engineering — that's the codec's choice. This
+    function is the canonical "load + pivot" step shared by every
+    fitter.
+    """
+    n_configs = max(config_names) + 1
+    Xs_rows: list[np.ndarray] = []
+    Y_rows: list[np.ndarray] = []
+    meta: list[tuple] = []
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        per_cfg: dict = defaultdict(lambda: defaultdict(lambda: math.inf))
+        for s in samples:
+            for zq in zq_targets:
+                if (
+                    s["zensim"] >= zq
+                    and s["bytes"] < per_cfg[zq][s["config_id"]]
+                ):
+                    per_cfg[zq][s["config_id"]] = s["bytes"]
+
+        for zq in zq_targets:
+            if not per_cfg[zq]:
+                continue
+            zq_norm = zq / 100.0
+            xs = np.concatenate(
+                [f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)]
+            )
+            y = np.full(n_configs, np.nan, dtype=np.float32)
+            for cfg, b in per_cfg[zq].items():
+                if b > 0 and not math.isinf(b):
+                    y[cfg] = math.log(b)
+            Xs_rows.append(xs)
+            Y_rows.append(y)
+            meta.append((image, size, zq))
+    return np.stack(Xs_rows), np.stack(Y_rows), meta
+
+
+def load_or_build_dataset(
+    pareto_path: Path,
+    features_path: Path,
+    keep_features: list[str] | None = None,
+    zq_targets: list[int] | None = None,
+) -> tuple[np.ndarray, np.ndarray, list[tuple], list[str], dict[int, str]]:
+    """Cached wrapper around `load_pareto_raw` + `load_features_raw` +
+    `build_dataset_simple`. First call: ~30 s. Subsequent calls with
+    the same inputs: ~100 ms.
+    """
+    if zq_targets is None:
+        zq_targets = ZQ_TARGETS_DEFAULT
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    key = _cache_key(pareto_path, features_path, keep_features)
+    cache_path = CACHE_DIR / f"dataset_{key}.npz"
+
+    if cache_path.exists():
+        sys.stderr.write(f"[cache] loading {cache_path.name}\n")
+        z = np.load(cache_path, allow_pickle=True)
+        Xs = z["Xs"]
+        Y = z["Y"]
+        meta = [tuple(m) for m in z["meta"].tolist()]
+        feat_cols = [str(c) for c in z["feat_cols"].tolist()]
+        config_names = {int(k): str(v) for k, v in z["config_names"].item().items()}
+        return Xs, Y, meta, feat_cols, config_names
+
+    sys.stderr.write(
+        f"[cache miss] building dataset from {pareto_path} + {features_path}...\n"
+    )
+    pareto, config_names = load_pareto_raw(pareto_path)
+    feats, feat_cols = load_features_raw(features_path, keep_features)
+    Xs, Y, meta = build_dataset_simple(pareto, config_names, feats, feat_cols, zq_targets)
+    np.savez(
+        cache_path,
+        Xs=Xs,
+        Y=Y,
+        meta=np.array(meta, dtype=object),
+        feat_cols=np.array(feat_cols),
+        config_names=np.array(dict(config_names), dtype=object),
+    )
+    sys.stderr.write(
+        f"[cache] wrote {cache_path.name} ({Xs.shape[0]} rows × "
+        f"{Xs.shape[1]} inputs × {Y.shape[1]} configs)\n"
+    )
+    return Xs, Y, meta, feat_cols, config_names
+
+
+# ---------- Train/val split (stable across runs) ----------
+
+
+def split_by_image(
+    meta: list[tuple], holdout_frac: float = HOLDOUT_FRAC_DEFAULT, seed: int = SEED_DEFAULT
+) -> tuple[np.ndarray, np.ndarray]:
+    """Image-level holdout split. Same image's rows always go to the
+    same side, regardless of size class or zq target."""
+    rng = np.random.default_rng(seed)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * holdout_frac))
+    val_set = set(images[:n_val])
+    train_idx = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    val_idx = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    return train_idx, val_idx
+
+
+# ---------- Parallel teacher training ----------
+
+
+def _fit_one_teacher(
+    cfg: int, X_tr: np.ndarray, y_col: np.ndarray, params: dict
+) -> tuple[int, Any]:
+    """Worker function for `train_teachers_parallel`. Returns
+    (cfg_idx, fitted_estimator_or_None)."""
+    mask = ~np.isnan(y_col)
+    if mask.sum() < 50:
+        return cfg, None
+    gbm = HistGradientBoostingRegressor(**params)
+    gbm.fit(X_tr[mask], y_col[mask])
+    return cfg, gbm
+
+
+def train_teachers_parallel(
+    X_tr: np.ndarray,
+    Y_tr: np.ndarray,
+    params: dict | None = None,
+    n_jobs: int = -1,
+    verbose: int = 0,
+) -> list[Any]:
+    """Train one HistGB teacher per output column in parallel.
+
+    With `n_jobs=-1` on a 16-core box, ~10× speedup over the serial
+    loop. Returns a list of length `Y_tr.shape[1]`; entries are
+    fitted estimators or `None` for columns with too few non-NaN
+    rows (< 50)."""
+    if params is None:
+        params = HISTGB_FULL
+    n_configs = Y_tr.shape[1]
+    sys.stderr.write(
+        f"[teachers] training {n_configs} per-config HistGB models in parallel "
+        f"(n_jobs={n_jobs}, max_iter={params['max_iter']}, max_depth={params['max_depth']})\n"
+    )
+    results = Parallel(n_jobs=n_jobs, backend="loky", verbose=verbose)(
+        delayed(_fit_one_teacher)(c, X_tr, Y_tr[:, c], params)
+        for c in range(n_configs)
+    )
+    teachers: list[Any] = [None] * n_configs
+    for cfg, model in results:
+        teachers[cfg] = model
+    n_trained = sum(1 for t in teachers if t is not None)
+    sys.stderr.write(f"[teachers] {n_trained}/{n_configs} models trained\n")
+    return teachers
+
+
+def teacher_predict_all(
+    teachers: list[Any], X: np.ndarray, fallback_means: np.ndarray
+) -> np.ndarray:
+    """Stack predictions from `teachers[c]` for c in 0..n_configs into
+    a (n_rows, n_configs) array. None entries get filled from
+    `fallback_means[c]` (typically `np.nanmean(Y_tr[:, c])`)."""
+    n_configs = len(teachers)
+    out = np.zeros((X.shape[0], n_configs), dtype=np.float32)
+    for c, t in enumerate(teachers):
+        if t is None:
+            fill = fallback_means[c]
+            out[:, c] = (
+                fill if (isinstance(fill, float) and not math.isnan(fill)) else 0.0
+            )
+        else:
+            out[:, c] = t.predict(X)
+    return out
+
+
+# ---------- Hybrid-heads-aware parallel teachers ----------
+
+
+def _fit_one_cell_target(
+    cell: int, X_tr: np.ndarray, y_col: np.ndarray, mask: np.ndarray, params: dict
+) -> tuple[int, Any]:
+    """Worker for `train_teachers_per_cell_parallel`. `mask` is the
+    reachable + valid-target rows for this cell × target combination.
+    Returns (cell_idx, fitted estimator or None)."""
+    if mask.sum() < 50:
+        return cell, None
+    gbm = HistGradientBoostingRegressor(**params)
+    gbm.fit(X_tr[mask], y_col[mask])
+    return cell, gbm
+
+
+def train_teachers_per_cell_parallel(
+    X_tr: np.ndarray,
+    Y_tr: np.ndarray,
+    reach_tr: np.ndarray,
+    extra_mask: np.ndarray | None = None,
+    params: dict | None = None,
+    n_jobs: int = -1,
+    label: str = "teachers",
+) -> list[Any]:
+    """Train one HistGB teacher per cell (column of `Y_tr`) in parallel.
+
+    Differs from `train_teachers_parallel` in two ways:
+      1. Honors a per-cell reachability mask `reach_tr` (e.g. "cell c
+         achieved target_zq on this row").
+      2. Optional `extra_mask` AND'd in (e.g. trellis-on subset for
+         the lambda head).
+
+    `Y_tr` shape: `(n_rows, n_cells)`. `reach_tr` shape:
+    `(n_rows, n_cells)` bool. Returns a list of n_cells fitted
+    estimators or None.
+
+    On a 16-core box trains 12 cells in ~30 s vs ~5 min serial. Drop-
+    in replacement for the `for c in range(n_cells): gbm.fit(...)`
+    loop in `zq_hybrid_heads.py`.
+    """
+    if params is None:
+        params = HISTGB_FULL
+    n_cells = Y_tr.shape[1]
+    sys.stderr.write(
+        f"[{label}] training {n_cells} per-cell HistGB models in parallel "
+        f"(n_jobs={n_jobs}, max_iter={params['max_iter']}, max_depth={params['max_depth']})\n"
+    )
+
+    def cell_mask(c: int) -> np.ndarray:
+        m = reach_tr[:, c] & ~np.isnan(Y_tr[:, c])
+        if extra_mask is not None:
+            m = m & extra_mask[:, c]
+        return m
+
+    results = Parallel(n_jobs=n_jobs, backend="loky")(
+        delayed(_fit_one_cell_target)(c, X_tr, Y_tr[:, c], cell_mask(c), params)
+        for c in range(n_cells)
+    )
+    teachers: list[Any] = [None] * n_cells
+    for cell, model in results:
+        teachers[cell] = model
+    n_trained = sum(1 for t in teachers if t is not None)
+    sys.stderr.write(f"[{label}] {n_trained}/{n_cells} models trained\n")
+    return teachers
+
+
+# ---------- Subsample for fast iteration ----------
+
+
+def subsample_for_iteration(
+    train_idx: np.ndarray,
+    val_idx: np.ndarray,
+    meta: list[tuple],
+    fraction: float = 0.5,
+    seed: int = SEED_DEFAULT,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Drop a random `1 - fraction` of training images (image-level,
+    not row-level) to speed up iteration. Val set kept full so
+    metrics remain comparable across runs.
+
+    Use during architecture / cross-term exploration. Switch back to
+    full training data for the production bake.
+    """
+    rng = np.random.default_rng(seed)
+    train_images = sorted({meta[i][0] for i in train_idx.tolist()})
+    rng.shuffle(train_images)
+    n_keep = max(1, int(len(train_images) * fraction))
+    keep_set = set(train_images[:n_keep])
+    new_train_idx = np.array(
+        [i for i in train_idx.tolist() if meta[i][0] in keep_set]
+    )
+    sys.stderr.write(
+        f"[subsample] keeping {len(keep_set)}/{len(train_images)} train images "
+        f"({len(new_train_idx)}/{len(train_idx)} rows, val unchanged)\n"
+    )
+    return new_train_idx, val_idx
+
+
+# ---------- Timing instrumentation ----------
+
+
+class StepTimer:
+    """Context-manager + accumulator for "where did the time go" reports.
+
+    Usage:
+
+        timer = StepTimer()
+        with timer.step("load"):
+            data = load_or_build_dataset(...)
+        with timer.step("teacher"):
+            teachers = train_teachers_parallel(...)
+        timer.report()  # prints accumulated wall-time per step
+    """
+
+    def __init__(self) -> None:
+        self._timings: list[tuple[str, float]] = []
+        self._t0: float | None = None
+        self._label: str | None = None
+
+    def step(self, label: str) -> "StepTimer":
+        self._label = label
+        return self
+
+    def __enter__(self) -> "StepTimer":
+        import time
+
+        self._t0 = time.monotonic()
+        sys.stderr.write(f"[timer] {self._label}…\n")
+        return self
+
+    def __exit__(self, *_) -> None:
+        import time
+
+        assert self._t0 is not None and self._label is not None
+        elapsed = time.monotonic() - self._t0
+        self._timings.append((self._label, elapsed))
+        sys.stderr.write(f"[timer] {self._label}: {elapsed:.2f}s\n")
+        self._t0 = None
+        self._label = None
+
+    def report(self) -> None:
+        total = sum(t for _, t in self._timings)
+        sys.stderr.write("\n[timer] step summary:\n")
+        for label, t in self._timings:
+            pct = (100.0 * t / total) if total > 0 else 0.0
+            sys.stderr.write(f"  {label:30s} {t:6.2f}s ({pct:4.1f}%)\n")
+        sys.stderr.write(f"  {'TOTAL':30s} {total:6.2f}s\n")
+
+
+# ---------- Argmin evaluation (shared) ----------
+
+
+def evaluate_argmin(
+    Y_pred: np.ndarray,
+    Y_actual: np.ndarray,
+    meta: list[tuple],
+    mask: np.ndarray,
+) -> dict:
+    """Standard argmin-overhead evaluation used by every fitter.
+
+    Returns mean / p50 / p75 / p90 mean overhead, argmin accuracy,
+    and a per-zq breakdown.
+    """
+    n_rows = Y_pred.shape[0]
+    overheads: list[float] = []
+    correct = 0
+    per_zq: dict = defaultdict(list)
+    for i in range(n_rows):
+        actual = Y_actual[i]
+        pred = Y_pred[i]
+        m = (~np.isnan(actual)) & mask
+        if not np.any(m):
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        a = int(np.argmin(ab))
+        p = int(np.argmin(pb))
+        if p == a:
+            correct += 1
+        ov = (ab[p] - ab[a]) / ab[a]
+        overheads.append(ov)
+        per_zq[meta[i][2]].append(ov)
+    if not overheads:
+        return {"n": 0}
+    arr = np.array(overheads)
+    return {
+        "n": int(len(arr)),
+        "argmin_acc": correct / len(arr),
+        "mean_pct": float(100 * arr.mean()),
+        "p50_pct": float(100 * np.percentile(arr, 50)),
+        "p75_pct": float(100 * np.percentile(arr, 75)),
+        "p90_pct": float(100 * np.percentile(arr, 90)),
+        "per_zq": {
+            tz: {
+                "n": len(v),
+                "mean": float(100 * np.mean(v)),
+                "p50": float(100 * np.percentile(v, 50)),
+                "p90": float(100 * np.percentile(v, 90)),
+            }
+            for tz, v in per_zq.items()
+        },
+    }

--- a/zenpicker/tools/capacity_sweep.py
+++ b/zenpicker/tools/capacity_sweep.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""
+MLP capacity + cross-term sweep on the 8-feature reduced schema.
+
+The v1.1 student takes +1.0pp vs the 19-feature v1.0 student because
+reducing 19→8 features also halves the engineered cross-term count,
+dropping MLP input dim 48→26. This script searches for an
+architecture+feature recipe that closes the gap without re-adding
+zenanalyze tiers.
+
+Method:
+1. Train HistGB teacher *once* on simple inputs (8 raw feats + size
+   onehot + log_pixels + zq). Cache its predictions. This is the
+   ceiling: the teacher's quality is what the student is trying to
+   match.
+2. Iterate over student variants (architecture × cross-term recipe)
+   on the same cached teacher targets. Train, evaluate, record.
+3. Report: variant comparison table, best variant, gap to teacher.
+
+Each student fit is ~2-5 min vs the teacher's ~10 min (run once).
+Total wall-time ~30-45 min for ~10 variants.
+"""
+
+import csv
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.neural_network import MLPRegressor
+from sklearn.preprocessing import StandardScaler
+
+PARETO = Path("benchmarks/zq_pareto_2026-04-29.tsv")
+FEATURES = Path("benchmarks/zq_pareto_features_2026-04-29.tsv")
+OUT_LOG = Path("benchmarks/zq_distill_capacity_sweep_2026-04-29.log")
+OUT_JSON = Path("benchmarks/zq_distill_capacity_sweep_2026-04-29.json")
+CACHE = Path("/tmp/zq_capacity_sweep_teacher_cache.npz")
+
+ZQ_TARGETS = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC = 0.20
+SEED = 0xCAFE
+
+KEEP_FEATURES = [
+    "feat_variance",
+    "feat_edge_density",
+    "feat_uniformity",
+    "feat_chroma_complexity",
+    "feat_cb_sharpness",
+    "feat_cr_sharpness",
+    "feat_high_freq_energy_ratio",
+    "feat_luma_histogram_entropy",
+]
+
+CONFIG_NAMES: dict = {}
+
+
+# ---------- Data loading (same as distill scripts) ----------
+
+
+def load_pareto(path):
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            CONFIG_NAMES.setdefault(cid, r["config_name"])
+            key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows
+
+
+def load_features(path):
+    feats = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        all_cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        cols = [c for c in KEEP_FEATURES if c in all_cols]
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in cols], dtype=np.float32
+            )
+    return feats, cols
+
+
+# ---------- Cross-term recipes (the knobs we vary) ----------
+
+
+def make_simple_features(f, log_px, size_oh, zq_norm):
+    """Simple input vector — what the teacher trains on (14 dims)."""
+    return np.concatenate([f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)])
+
+
+def make_engineered_v1(f, log_px, size_oh, zq_norm):
+    """v1.1 (current) recipe: 8 + 4 + 5 + 8 + 1 = 26 dims."""
+    return np.concatenate([
+        f,
+        size_oh,
+        np.array([log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px], dtype=np.float32),
+        zq_norm * f,
+        np.array([0.0], dtype=np.float32),  # icc placeholder
+    ])
+
+
+def make_engineered_v2_zqsq(f, log_px, size_oh, zq_norm):
+    """v2: add zq²×feat cross terms. 26 + 8 = 34 dims."""
+    return np.concatenate([
+        f,
+        size_oh,
+        np.array([log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px], dtype=np.float32),
+        zq_norm * f,
+        zq_norm * zq_norm * f,
+        np.array([0.0], dtype=np.float32),
+    ])
+
+
+def make_engineered_v3_logpx(f, log_px, size_oh, zq_norm):
+    """v3: add log_pixels×feat cross terms. 26 + 8 = 34 dims."""
+    return np.concatenate([
+        f,
+        size_oh,
+        np.array([log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px], dtype=np.float32),
+        zq_norm * f,
+        log_px * f,
+        np.array([0.0], dtype=np.float32),
+    ])
+
+
+def make_engineered_v4_full(f, log_px, size_oh, zq_norm):
+    """v4: zq²×feat AND log_px×feat. 26 + 16 = 42 dims."""
+    return np.concatenate([
+        f,
+        size_oh,
+        np.array([log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px], dtype=np.float32),
+        zq_norm * f,
+        zq_norm * zq_norm * f,
+        log_px * f,
+        np.array([0.0], dtype=np.float32),
+    ])
+
+
+def make_engineered_v5_pairs(f, log_px, size_oh, zq_norm):
+    """v5: zq×feat plus a small set of feat×feat pairs (the most
+    informative pairs from a quick correlation guess: cb×cr, hf×entropy,
+    var×edge). 26 + 3 = 29 dims."""
+    pairs = np.array(
+        [
+            f[4] * f[5],  # cb_sharpness × cr_sharpness
+            f[6] * f[7],  # hf_energy_ratio × luma_entropy
+            f[0] * f[1],  # variance × edge_density
+        ],
+        dtype=np.float32,
+    )
+    return np.concatenate([
+        f,
+        size_oh,
+        np.array([log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px], dtype=np.float32),
+        zq_norm * f,
+        pairs,
+        np.array([0.0], dtype=np.float32),
+    ])
+
+
+CROSS_RECIPES = {
+    "v1_baseline": make_engineered_v1,
+    "v2_zqsq": make_engineered_v2_zqsq,
+    "v3_logpx": make_engineered_v3_logpx,
+    "v4_full": make_engineered_v4_full,
+    "v5_pairs": make_engineered_v5_pairs,
+}
+
+
+# ---------- Architecture variants ----------
+
+ARCHITECTURES = {
+    "h64x2":   (64, 64),
+    "h96x2":   (96, 96),
+    "h128x2":  (128, 128),
+    "h64x3":   (64, 64, 64),
+    "h96x3":   (96, 96, 96),
+}
+
+
+# ---------- Build datasets per recipe ----------
+
+
+def build_dataset_for_recipe(pareto, feats, recipe_fn):
+    n_configs = max(CONFIG_NAMES) + 1
+    Xs_rows, Xe_rows, Y_rows, meta = [], [], [], []
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        per_cfg = defaultdict(lambda: defaultdict(lambda: math.inf))
+        for s in samples:
+            for zq in ZQ_TARGETS:
+                if s["zensim"] >= zq and s["bytes"] < per_cfg[zq][s["config_id"]]:
+                    per_cfg[zq][s["config_id"]] = s["bytes"]
+
+        for zq in ZQ_TARGETS:
+            if not per_cfg[zq]:
+                continue
+            zq_norm = zq / 100.0
+            xs = make_simple_features(f, log_px, size_oh, zq_norm)
+            xe = recipe_fn(f, log_px, size_oh, zq_norm)
+            y = np.full(n_configs, np.nan, dtype=np.float32)
+            for cfg, b in per_cfg[zq].items():
+                if b > 0 and not math.isinf(b):
+                    y[cfg] = math.log(b)
+            Xs_rows.append(xs)
+            Xe_rows.append(xe)
+            Y_rows.append(y)
+            meta.append((image, size, zq))
+    return np.stack(Xs_rows), np.stack(Xe_rows), np.stack(Y_rows), meta
+
+
+def evaluate(Y_pred, Y_actual, meta):
+    overheads, correct = [], 0
+    for i in range(Y_pred.shape[0]):
+        actual = Y_actual[i]
+        pred = Y_pred[i]
+        m = ~np.isnan(actual)
+        if not np.any(m):
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        a = int(np.argmin(ab))
+        p = int(np.argmin(pb))
+        if p == a:
+            correct += 1
+        overheads.append((ab[p] - ab[a]) / ab[a])
+    arr = np.array(overheads)
+    return {
+        "n": int(len(arr)),
+        "argmin_acc": correct / len(arr),
+        "mean_pct": float(100 * arr.mean()),
+        "p50_pct": float(100 * np.percentile(arr, 50)),
+        "p90_pct": float(100 * np.percentile(arr, 90)),
+    }
+
+
+# ---------- Teacher (run once, cached) ----------
+
+
+def train_teacher(Xs_tr, Y_tr, Xs_va, n_configs):
+    sys.stderr.write(f"\nTraining teacher on simple inputs (dim={Xs_tr.shape[1]})...\n")
+    teachers = []
+    cfg_means = np.nanmean(Y_tr, axis=0)
+    for cfg in range(n_configs):
+        mask = ~np.isnan(Y_tr[:, cfg])
+        if mask.sum() < 50:
+            teachers.append(None)
+            continue
+        gbm = HistGradientBoostingRegressor(
+            max_iter=400, max_depth=8, learning_rate=0.05,
+            l2_regularization=0.5, random_state=SEED,
+        )
+        gbm.fit(Xs_tr[mask], Y_tr[mask, cfg])
+        teachers.append(gbm)
+        if (cfg + 1) % 30 == 0:
+            sys.stderr.write(f"  {cfg+1}/{n_configs} teachers trained\n")
+
+    soft_tr = np.zeros((Xs_tr.shape[0], n_configs), dtype=np.float32)
+    soft_va = np.zeros((Xs_va.shape[0], n_configs), dtype=np.float32)
+    for cfg in range(n_configs):
+        if teachers[cfg] is None:
+            soft_tr[:, cfg] = cfg_means[cfg]
+            soft_va[:, cfg] = cfg_means[cfg]
+        else:
+            soft_tr[:, cfg] = teachers[cfg].predict(Xs_tr)
+            soft_va[:, cfg] = teachers[cfg].predict(Xs_va)
+    return soft_tr, soft_va
+
+
+# ---------- Student fit ----------
+
+
+def fit_student(Xe_tr, soft_tr, Xe_va, hidden_layers, label):
+    sys.stderr.write(f"\nStudent {label}: arch={hidden_layers}, dim={Xe_tr.shape[1]}\n")
+    scaler = StandardScaler()
+    Xe_tr_s = scaler.fit_transform(Xe_tr)
+    Xe_va_s = scaler.transform(Xe_va)
+    student = MLPRegressor(
+        hidden_layer_sizes=hidden_layers,
+        activation="relu",
+        solver="adam",
+        learning_rate_init=2e-3,
+        batch_size=512,
+        max_iter=500,
+        early_stopping=True,
+        validation_fraction=0.1,
+        n_iter_no_change=30,
+        tol=1e-6,
+        random_state=SEED,
+        verbose=False,
+    )
+    student.fit(Xe_tr_s, soft_tr)
+    Y_va_pred = student.predict(Xe_va_s)
+    n_params = sum(c.size + i.size for c, i in zip(student.coefs_, student.intercepts_))
+    return Y_va_pred, n_params, student.n_iter_, student.loss_
+
+
+# ---------- Main ----------
+
+
+def main():
+    sys.stderr.write(f"Loading {PARETO}...\n")
+    pareto = load_pareto(PARETO)
+    feats, feat_cols = load_features(FEATURES)
+    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features\n")
+
+    # Build the train/val split once on the v1 recipe; the split
+    # depends only on image identity, not feature engineering.
+    Xs, Xe_v1, Y, meta = build_dataset_for_recipe(pareto, feats, make_engineered_v1)
+    n_configs = Y.shape[1]
+
+    rng = np.random.default_rng(SEED)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * HOLDOUT_FRAC))
+    val_set = set(images[:n_val])
+    train_idx = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    val_idx = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    sys.stderr.write(f"Train rows: {len(train_idx)}, val rows: {len(val_idx)}\n")
+    meta_va = [meta[i] for i in val_idx]
+
+    Xs_tr, Xs_va = Xs[train_idx], Xs[val_idx]
+    Y_tr, Y_va = Y[train_idx], Y[val_idx]
+
+    # Teacher: train once or load from cache.
+    if CACHE.exists():
+        sys.stderr.write(f"\nLoading teacher predictions from cache: {CACHE}\n")
+        cached = np.load(CACHE)
+        soft_tr = cached["soft_tr"]
+        soft_va = cached["soft_va"]
+        if soft_tr.shape != (Xs_tr.shape[0], n_configs):
+            sys.stderr.write(f"  cache shape mismatch — retraining\n")
+            soft_tr, soft_va = train_teacher(Xs_tr, Y_tr, Xs_va, n_configs)
+            np.savez(CACHE, soft_tr=soft_tr, soft_va=soft_va)
+    else:
+        soft_tr, soft_va = train_teacher(Xs_tr, Y_tr, Xs_va, n_configs)
+        np.savez(CACHE, soft_tr=soft_tr, soft_va=soft_va)
+        sys.stderr.write(f"Cached teacher predictions to {CACHE}\n")
+
+    teacher_metrics = evaluate(soft_va, Y_va, meta_va)
+    sys.stderr.write(
+        f"\nTeacher (ceiling): mean {teacher_metrics['mean_pct']:.2f}% "
+        f"argmin {teacher_metrics['argmin_acc']:.1%}\n"
+    )
+
+    # Sweep students.
+    results = []
+    for recipe_name, recipe_fn in CROSS_RECIPES.items():
+        # Rebuild Xe with this recipe (same train/val split).
+        _, Xe_recipe, _, _ = build_dataset_for_recipe(pareto, feats, recipe_fn)
+        Xe_tr_r, Xe_va_r = Xe_recipe[train_idx], Xe_recipe[val_idx]
+
+        for arch_name, arch in ARCHITECTURES.items():
+            label = f"{recipe_name}/{arch_name}"
+            try:
+                Y_pred, n_params, n_iter, loss = fit_student(
+                    Xe_tr_r, soft_tr, Xe_va_r, arch, label
+                )
+                m = evaluate(Y_pred, Y_va, meta_va)
+                results.append({
+                    "label": label,
+                    "recipe": recipe_name,
+                    "arch": arch_name,
+                    "input_dim": Xe_recipe.shape[1],
+                    "hidden": list(arch),
+                    "n_params": n_params,
+                    "kb_f32": round(n_params * 4 / 1024, 1),
+                    "kb_f16": round(n_params * 2 / 1024, 1),
+                    "n_iter": n_iter,
+                    "loss": float(loss),
+                    "metrics": m,
+                })
+                sys.stderr.write(
+                    f"  {label}: mean {m['mean_pct']:.2f}% argmin {m['argmin_acc']:.1%}  "
+                    f"params={n_params} ({n_params*2/1024:.1f}KB f16)\n"
+                )
+            except Exception as e:
+                sys.stderr.write(f"  {label}: FAILED — {e}\n")
+
+    # Sort by mean overhead.
+    results.sort(key=lambda r: r["metrics"]["mean_pct"])
+
+    out = {
+        "teacher": teacher_metrics,
+        "students": results,
+        "n_configs": n_configs,
+        "feat_cols": feat_cols,
+    }
+    OUT_JSON.write_text(json.dumps(out, indent=2))
+
+    lines = []
+    def w(s):
+        lines.append(s)
+        sys.stderr.write(s + "\n")
+
+    w("\n# MLP capacity + cross-term sweep — 8-feature reduced schema")
+    w(f"Train rows: {len(train_idx)}, val rows: {len(val_idx)}")
+    w(f"Teacher (HistGB ceiling): mean {teacher_metrics['mean_pct']:.2f}%  "
+      f"argmin {teacher_metrics['argmin_acc']:.1%}")
+    w(f"Existing v1.1 student: mean 8.20% argmin 10.5% (h64x2, recipe=v1_baseline, 13688 params)")
+    w("")
+    w("## Student variants (sorted by mean overhead, best first)")
+    w(f"{'rank':>4s} {'recipe/arch':25s} {'in_dim':>7s} {'params':>8s} {'kb_f16':>7s} "
+      f"{'mean':>7s} {'p50':>7s} {'p90':>7s} {'argmin':>7s}")
+    w("-" * 95)
+    for rank, r in enumerate(results, 1):
+        m = r["metrics"]
+        w(f"{rank:>4d} {r['label']:25s} {r['input_dim']:>7d} {r['n_params']:>8d} "
+          f"{r['kb_f16']:>6.1f} K {m['mean_pct']:>6.2f}% {m['p50_pct']:>6.2f}% "
+          f"{m['p90_pct']:>6.2f}% {m['argmin_acc']:>6.1%}")
+
+    if results:
+        best = results[0]
+        gap_to_teacher = best["metrics"]["mean_pct"] - teacher_metrics["mean_pct"]
+        w(f"\n## Best: {best['label']}")
+        w(f"  mean overhead: {best['metrics']['mean_pct']:.2f}% (gap to teacher: {gap_to_teacher:+.2f}pp)")
+        w(f"  argmin_acc:    {best['metrics']['argmin_acc']:.1%}")
+        w(f"  size:          {best['kb_f16']} KB f16, {best['kb_f32']} KB f32")
+        w(f"  arch:          {best['hidden']}, input_dim={best['input_dim']}")
+
+    OUT_LOG.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/zenpicker/tools/feature_ablation.py
+++ b/zenpicker/tools/feature_ablation.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""
+Feature ablation for the Pareto controller's HistGB model.
+
+Goal: rank zenanalyze features by their contribution to picker
+accuracy, then drop the ones whose accuracy contribution doesn't
+justify their compute cost on the hot path.
+
+Method:
+1. Train baseline HistGB (all 19 features) — measure mean argmin
+   overhead.
+2. For each feature, retrain with that feature dropped (replaced
+   with constant 0). Measure overhead delta.
+3. Forward greedy: starting from the empty set, repeatedly add the
+   feature whose inclusion gives the largest overhead reduction.
+   Record the Pareto curve (n_features kept vs overhead).
+
+The forward greedy is the actionable output: it tells us "with K
+features, here's the best K and here's the overhead." User picks K
+based on per-feature compute cost in zenanalyze.
+
+Inputs:
+- benchmarks/zq_pareto_2026-04-29.tsv
+- benchmarks/zq_pareto_features_2026-04-29.tsv
+
+Outputs:
+- benchmarks/zq_feature_ablation_2026-04-29.log
+- benchmarks/zq_feature_ablation_2026-04-29.json
+"""
+
+import csv
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+PARETO = Path("benchmarks/zq_pareto_2026-04-29.tsv")
+FEATURES = Path("benchmarks/zq_pareto_features_2026-04-29.tsv")
+OUT_LOG = Path("benchmarks/zq_feature_ablation_2026-04-29.log")
+OUT_JSON = Path("benchmarks/zq_feature_ablation_2026-04-29.json")
+
+ZQ_TARGETS = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC = 0.20
+SEED = 0xCAFE
+
+# Light HistGB tuned for speed across many ablation points. Quality
+# drops by ~1-2pp vs the production fit (which uses max_iter=400,
+# max_depth=8) but the *ranking* across feature ablations is stable
+# — same features end up most/least useful at lower compute. Total
+# wall-time at 100/4: ~50 min for baseline + 19 LOO. Forward-greedy
+# phase skipped — LOO ranking is enough to identify which features
+# can be dropped, and forward greedy adds another ~120 min.
+HISTGB_KW = dict(
+    max_iter=100,
+    max_depth=4,
+    learning_rate=0.1,
+    l2_regularization=0.5,
+    random_state=SEED,
+)
+# Skip forward greedy if True (LOO is sufficient for the ranking).
+SKIP_GREEDY = True
+
+CONFIG_NAMES: dict = {}
+
+
+def load_pareto(path):
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            CONFIG_NAMES.setdefault(cid, r["config_name"])
+            key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows
+
+
+def load_features(path):
+    feats = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in cols], dtype=np.float32
+            )
+    return feats, cols
+
+
+def build_dataset(pareto, feats, feat_cols):
+    """X: (n, 19 + 4 + 1) = 19 features + size onehot + zq.
+
+    Y: log-bytes per config; np.nan if config doesn't reach zq.
+    meta: (image, size, zq) per row.
+    """
+    n_configs = max(CONFIG_NAMES) + 1
+    X_rows, Y_rows, meta = [], [], []
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        per_cfg = defaultdict(lambda: defaultdict(lambda: math.inf))
+        for s in samples:
+            for zq in ZQ_TARGETS:
+                if s["zensim"] >= zq and s["bytes"] < per_cfg[zq][s["config_id"]]:
+                    per_cfg[zq][s["config_id"]] = s["bytes"]
+
+        for zq in ZQ_TARGETS:
+            if not per_cfg[zq]:
+                continue
+            zq_norm = zq / 100.0
+            x = np.concatenate([f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)])
+            y = np.full(n_configs, np.nan, dtype=np.float32)
+            for cfg, b in per_cfg[zq].items():
+                if b > 0 and not math.isinf(b):
+                    y[cfg] = math.log(b)
+            X_rows.append(x)
+            Y_rows.append(y)
+            meta.append((image, size, zq))
+    return np.stack(X_rows), np.stack(Y_rows), meta
+
+
+def evaluate_argmin(Y_pred, Y_actual, meta, mask):
+    n = Y_pred.shape[0]
+    overheads = []
+    correct = 0
+    per_zq = defaultdict(list)
+    for i in range(n):
+        actual = Y_actual[i]
+        pred = Y_pred[i]
+        m = (~np.isnan(actual)) & mask
+        if not np.any(m):
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        actual_best = int(np.argmin(ab))
+        pred_best = int(np.argmin(pb))
+        if pred_best == actual_best:
+            correct += 1
+        ov = (ab[pred_best] - ab[actual_best]) / ab[actual_best]
+        overheads.append(ov)
+        per_zq[meta[i][2]].append(ov)
+    if not overheads:
+        return None
+    arr = np.array(overheads)
+    return {
+        "n": int(len(arr)),
+        "argmin_acc": correct / len(arr),
+        "mean_pct": float(100 * arr.mean()),
+        "p50_pct": float(100 * np.percentile(arr, 50)),
+        "p90_pct": float(100 * np.percentile(arr, 90)),
+    }
+
+
+def train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, mask_cols, n_configs):
+    """Train HistGB per-config using only the columns where mask_cols is True.
+
+    Returns metrics dict.
+    """
+    X_tr_m = X_tr[:, mask_cols]
+    X_va_m = X_va[:, mask_cols]
+
+    Y_pred = np.zeros_like(Y_va)
+    for cfg in range(n_configs):
+        mask = ~np.isnan(Y_tr[:, cfg])
+        if mask.sum() < 50:
+            Y_pred[:, cfg] = np.nanmean(Y_tr[:, cfg]) if mask.any() else 0.0
+            continue
+        gbm = HistGradientBoostingRegressor(**HISTGB_KW)
+        gbm.fit(X_tr_m[mask], Y_tr[mask, cfg])
+        Y_pred[:, cfg] = gbm.predict(X_va_m)
+
+    return evaluate_argmin(Y_pred, Y_va, meta_va, np.ones(n_configs, dtype=bool))
+
+
+def main():
+    sys.stderr.write(f"Loading {PARETO}...\n")
+    pareto = load_pareto(PARETO)
+    feats, feat_cols = load_features(FEATURES)
+    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features\n")
+
+    X, Y, meta = build_dataset(pareto, feats, feat_cols)
+    n_configs = Y.shape[1]
+    sys.stderr.write(f"Decision rows: {len(X)} × {n_configs} configs\n")
+
+    rng = np.random.default_rng(SEED)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * HOLDOUT_FRAC))
+    val_set = set(images[:n_val])
+    train_idx = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    val_idx = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    sys.stderr.write(f"Train rows: {len(train_idx)}, val rows: {len(val_idx)}\n")
+
+    X_tr, Y_tr = X[train_idx], Y[train_idx]
+    X_va, Y_va = X[val_idx], Y[val_idx]
+    meta_va = [meta[i] for i in val_idx]
+
+    n_feat = len(feat_cols)
+    n_total = X.shape[1]  # n_feat + 4 (size onehot) + 1 (zq)
+    feat_indices = list(range(n_feat))  # we ablate features only; keep size+zq
+    fixed_indices = list(range(n_feat, n_total))
+
+    # ============ Phase 1: baseline (all features) ============
+    sys.stderr.write("\n[1/3] Baseline (all 19 features)...\n")
+    baseline_mask = np.ones(n_total, dtype=bool)
+    baseline = train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, baseline_mask, n_configs)
+    sys.stderr.write(f"  baseline: mean overhead {baseline['mean_pct']:.2f}% argmin_acc {baseline['argmin_acc']:.1%}\n")
+
+    # ============ Phase 2: leave-one-out per feature ============
+    sys.stderr.write(f"\n[2/3] Leave-one-out across {n_feat} features...\n")
+    loo_results = {}
+    for fi in range(n_feat):
+        mask = np.ones(n_total, dtype=bool)
+        mask[fi] = False
+        m = train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, mask, n_configs)
+        loo_results[feat_cols[fi]] = m
+        delta = m["mean_pct"] - baseline["mean_pct"]
+        sys.stderr.write(f"  drop {feat_cols[fi]:35s}: {m['mean_pct']:.2f}% (Δ {delta:+.2f}pp)\n")
+
+    # Sort by Δ (largest hurt = most important).
+    loo_sorted = sorted(loo_results.items(), key=lambda kv: -kv[1]["mean_pct"])
+    sys.stderr.write("\n  Most important (drop hurts most):\n")
+    for name, m in loo_sorted[:5]:
+        sys.stderr.write(f"    {name}: drop → {m['mean_pct']:.2f}% (Δ {m['mean_pct'] - baseline['mean_pct']:+.2f}pp)\n")
+    sys.stderr.write("  Least important (drop hurts least):\n")
+    for name, m in loo_sorted[-5:]:
+        sys.stderr.write(f"    {name}: drop → {m['mean_pct']:.2f}% (Δ {m['mean_pct'] - baseline['mean_pct']:+.2f}pp)\n")
+
+    # ============ Phase 3: forward greedy (optional) ============
+    greedy_curve = []
+    if SKIP_GREEDY:
+        sys.stderr.write("\n[3/3] Forward greedy SKIPPED (LOO ranking is sufficient).\n")
+        run_greedy = False
+    else:
+        sys.stderr.write("\n[3/3] Forward greedy (add the feature that helps most until plateau)...\n")
+        run_greedy = True
+        selected = set()
+        # K=0 baseline (no features, just size onehot + zq).
+        mask0 = np.zeros(n_total, dtype=bool)
+        mask0[fixed_indices] = True
+        m0 = train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, mask0, n_configs)
+        greedy_curve.append({"k": 0, "selected": [], "metrics": m0})
+        sys.stderr.write(f"  K=0 (size+zq only): {m0['mean_pct']:.2f}%\n")
+
+        candidate_pool = [feat_cols.index(name) for name, _ in loo_sorted[:12]]
+        candidate_pool_set = set(candidate_pool)
+
+    while run_greedy and candidate_pool_set:
+        best_fi = None
+        best_metrics = None
+        for fi in candidate_pool_set:
+            mask = np.zeros(n_total, dtype=bool)
+            mask[fixed_indices] = True
+            for s in selected:
+                mask[s] = True
+            mask[fi] = True
+            m = train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, mask, n_configs)
+            if best_metrics is None or m["mean_pct"] < best_metrics["mean_pct"]:
+                best_fi = fi
+                best_metrics = m
+        selected.add(best_fi)
+        candidate_pool_set.remove(best_fi)
+        greedy_curve.append(
+            {
+                "k": len(selected),
+                "selected": [feat_cols[i] for i in sorted(selected)],
+                "added": feat_cols[best_fi],
+                "metrics": best_metrics,
+            }
+        )
+        sys.stderr.write(
+            f"  K={len(selected):2d} (+{feat_cols[best_fi]:30s}): {best_metrics['mean_pct']:.2f}% "
+            f"argmin_acc {best_metrics['argmin_acc']:.1%}\n"
+        )
+
+    # ============ Persist ============
+    out = {
+        "baseline": baseline,
+        "leave_one_out": loo_results,
+        "leave_one_out_ranked": [
+            {"feature": name, "mean_pct": m["mean_pct"], "delta_pp": m["mean_pct"] - baseline["mean_pct"]}
+            for name, m in loo_sorted
+        ],
+        "greedy_curve": greedy_curve,
+        "feat_cols": feat_cols,
+        "histgb_params": HISTGB_KW,
+    }
+    OUT_JSON.write_text(json.dumps(out, indent=2))
+
+    lines = []
+
+    def w(s):
+        lines.append(s)
+        sys.stderr.write(s + "\n")
+
+    w("\n# Feature ablation — Pareto controller HistGB")
+    w(f"Train rows: {len(X_tr)}, val rows: {len(X_va)}")
+    w(f"HistGB: {HISTGB_KW}")
+    w("")
+    w(f"## Baseline (all {n_feat} features)")
+    w(f"mean overhead: {baseline['mean_pct']:.2f}%  argmin_acc: {baseline['argmin_acc']:.1%}")
+    w("")
+    w("## Leave-one-out (sorted by Δ vs baseline, largest hurt first)")
+    w(f"{'feature':40s} {'overhead':>10s} {'Δ vs base':>10s}")
+    w("-" * 65)
+    for name, m in loo_sorted:
+        delta = m["mean_pct"] - baseline["mean_pct"]
+        w(f"{name:40s} {m['mean_pct']:>9.2f}%  {delta:>+8.2f}pp")
+    w("")
+    w("## Forward greedy curve (cumulative best feature subsets)")
+    w(f"{'K':>3s} {'overhead':>10s} {'argmin_acc':>11s}  added")
+    w("-" * 65)
+    for entry in greedy_curve:
+        m = entry["metrics"]
+        added = entry.get("added", "(none)")
+        w(f"{entry['k']:>3d} {m['mean_pct']:>9.2f}%  {m['argmin_acc']:>10.1%}   +{added}")
+
+    OUT_LOG.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/zenpicker/tools/feature_group_ablation.py
+++ b/zenpicker/tools/feature_group_ablation.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""
+Group-ablation companion to `zq_feature_ablation.py`.
+
+Single-feature LOO is blind to correlated feature clusters: each
+individual drop looks marginal because siblings compensate. This
+script ablates *groups* of related features to test whether the
+group is collectively load-bearing or not.
+
+Groups (mapped to zenanalyze tiers):
+  alpha             — alpha_present, alpha_used_fraction, alpha_bimodal_score
+  chroma_sharpness  — 8 features: cb/cr × {sharpness, horiz, vert, peak}
+  palette           — distinct_color_bins, flat_color_block_ratio
+  tier3_dct         — high_freq_energy_ratio, luma_histogram_entropy
+  tier1_basic       — variance, edge_density, uniformity, chroma_complexity
+
+Same plumbing as `zq_feature_ablation.py`; only the masking changes.
+"""
+
+import csv
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+PARETO = Path("benchmarks/zq_pareto_2026-04-29.tsv")
+FEATURES = Path("benchmarks/zq_pareto_features_2026-04-29.tsv")
+OUT_LOG = Path("benchmarks/zq_feature_group_ablation_2026-04-29.log")
+OUT_JSON = Path("benchmarks/zq_feature_group_ablation_2026-04-29.json")
+
+ZQ_TARGETS = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC = 0.20
+SEED = 0xCAFE
+
+HISTGB_KW = dict(
+    max_iter=100,
+    max_depth=4,
+    learning_rate=0.1,
+    l2_regularization=0.5,
+    random_state=SEED,
+)
+
+GROUPS = {
+    "alpha": [
+        "feat_alpha_present",
+        "feat_alpha_used_fraction",
+        "feat_alpha_bimodal_score",
+    ],
+    "chroma_sharpness": [
+        "feat_cb_sharpness",
+        "feat_cr_sharpness",
+        "feat_cb_horiz_sharpness",
+        "feat_cb_vert_sharpness",
+        "feat_cb_peak_sharpness",
+        "feat_cr_horiz_sharpness",
+        "feat_cr_vert_sharpness",
+        "feat_cr_peak_sharpness",
+    ],
+    "palette": [
+        "feat_distinct_color_bins",
+        "feat_flat_color_block_ratio",
+    ],
+    "tier3_dct": [
+        "feat_high_freq_energy_ratio",
+        "feat_luma_histogram_entropy",
+    ],
+    "tier1_basic": [
+        "feat_variance",
+        "feat_edge_density",
+        "feat_uniformity",
+        "feat_chroma_complexity",
+    ],
+}
+
+# Bonus: cumulative drops in the order LOO suggested would help.
+# Test "drop everything LOO said was zero/negative simultaneously".
+LOO_DROPS_NEGATIVE_OR_ZERO = [
+    "feat_distinct_color_bins",
+    "feat_cr_peak_sharpness",
+    "feat_cb_vert_sharpness",
+    "feat_flat_color_block_ratio",
+    "feat_alpha_bimodal_score",
+    "feat_alpha_used_fraction",
+    "feat_alpha_present",
+    "feat_variance",
+]
+
+CONFIG_NAMES: dict = {}
+
+
+def load_pareto(path):
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            CONFIG_NAMES.setdefault(cid, r["config_name"])
+            key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows
+
+
+def load_features(path):
+    feats = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in cols], dtype=np.float32
+            )
+    return feats, cols
+
+
+def build_dataset(pareto, feats, feat_cols):
+    n_configs = max(CONFIG_NAMES) + 1
+    X_rows, Y_rows, meta = [], [], []
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        per_cfg = defaultdict(lambda: defaultdict(lambda: math.inf))
+        for s in samples:
+            for zq in ZQ_TARGETS:
+                if s["zensim"] >= zq and s["bytes"] < per_cfg[zq][s["config_id"]]:
+                    per_cfg[zq][s["config_id"]] = s["bytes"]
+
+        for zq in ZQ_TARGETS:
+            if not per_cfg[zq]:
+                continue
+            zq_norm = zq / 100.0
+            x = np.concatenate([f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)])
+            y = np.full(n_configs, np.nan, dtype=np.float32)
+            for cfg, b in per_cfg[zq].items():
+                if b > 0 and not math.isinf(b):
+                    y[cfg] = math.log(b)
+            X_rows.append(x)
+            Y_rows.append(y)
+            meta.append((image, size, zq))
+    return np.stack(X_rows), np.stack(Y_rows), meta
+
+
+def evaluate_argmin(Y_pred, Y_actual, meta, mask):
+    n = Y_pred.shape[0]
+    overheads = []
+    correct = 0
+    for i in range(n):
+        actual = Y_actual[i]
+        pred = Y_pred[i]
+        m = (~np.isnan(actual)) & mask
+        if not np.any(m):
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        actual_best = int(np.argmin(ab))
+        pred_best = int(np.argmin(pb))
+        if pred_best == actual_best:
+            correct += 1
+        ov = (ab[pred_best] - ab[actual_best]) / ab[actual_best]
+        overheads.append(ov)
+    if not overheads:
+        return None
+    arr = np.array(overheads)
+    return {
+        "n": int(len(arr)),
+        "argmin_acc": correct / len(arr),
+        "mean_pct": float(100 * arr.mean()),
+        "p50_pct": float(100 * np.percentile(arr, 50)),
+        "p90_pct": float(100 * np.percentile(arr, 90)),
+    }
+
+
+def train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, mask_cols, n_configs):
+    X_tr_m = X_tr[:, mask_cols]
+    X_va_m = X_va[:, mask_cols]
+    Y_pred = np.zeros_like(Y_va)
+    for cfg in range(n_configs):
+        mask = ~np.isnan(Y_tr[:, cfg])
+        if mask.sum() < 50:
+            Y_pred[:, cfg] = np.nanmean(Y_tr[:, cfg]) if mask.any() else 0.0
+            continue
+        gbm = HistGradientBoostingRegressor(**HISTGB_KW)
+        gbm.fit(X_tr_m[mask], Y_tr[mask, cfg])
+        Y_pred[:, cfg] = gbm.predict(X_va_m)
+    return evaluate_argmin(Y_pred, Y_va, meta_va, np.ones(n_configs, dtype=bool))
+
+
+def main():
+    sys.stderr.write(f"Loading {PARETO}...\n")
+    pareto = load_pareto(PARETO)
+    feats, feat_cols = load_features(FEATURES)
+    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features\n")
+
+    X, Y, meta = build_dataset(pareto, feats, feat_cols)
+    n_configs = Y.shape[1]
+    n_total = X.shape[1]
+
+    rng = np.random.default_rng(SEED)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * HOLDOUT_FRAC))
+    val_set = set(images[:n_val])
+    train_idx = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    val_idx = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    sys.stderr.write(f"Train rows: {len(train_idx)}, val rows: {len(val_idx)}\n")
+
+    X_tr, Y_tr = X[train_idx], Y[train_idx]
+    X_va, Y_va = X[val_idx], Y[val_idx]
+    meta_va = [meta[i] for i in val_idx]
+
+    feat_idx = {name: i for i, name in enumerate(feat_cols)}
+
+    # Baseline.
+    sys.stderr.write("\nBaseline (all features)...\n")
+    baseline = train_and_eval(
+        X_tr, Y_tr, X_va, Y_va, meta_va, np.ones(n_total, dtype=bool), n_configs
+    )
+    sys.stderr.write(
+        f"  baseline: {baseline['mean_pct']:.2f}% argmin_acc {baseline['argmin_acc']:.1%}\n"
+    )
+
+    # Group ablations.
+    sys.stderr.write("\nGroup ablations (drop entire group)...\n")
+    group_results = {}
+    for gname, gfeats in GROUPS.items():
+        mask = np.ones(n_total, dtype=bool)
+        missing = []
+        for fname in gfeats:
+            if fname in feat_idx:
+                mask[feat_idx[fname]] = False
+            else:
+                missing.append(fname)
+        if missing:
+            sys.stderr.write(f"  WARN group '{gname}' missing features: {missing}\n")
+        m = train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, mask, n_configs)
+        group_results[gname] = m
+        delta = m["mean_pct"] - baseline["mean_pct"]
+        sys.stderr.write(
+            f"  drop {gname:20s} ({len(gfeats)} feats): {m['mean_pct']:.2f}% (Δ {delta:+.2f}pp)\n"
+        )
+
+    # Combined LOO-suggested drops.
+    sys.stderr.write("\nCombined drop: every LOO-zero-or-negative feature simultaneously...\n")
+    mask = np.ones(n_total, dtype=bool)
+    dropped = []
+    for fname in LOO_DROPS_NEGATIVE_OR_ZERO:
+        if fname in feat_idx:
+            mask[feat_idx[fname]] = False
+            dropped.append(fname)
+    n_dropped = len(dropped)
+    n_remaining = sum(1 for n in feat_cols if n not in dropped)
+    combined = train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, mask, n_configs)
+    sys.stderr.write(
+        f"  drop {n_dropped} feats, keep {n_remaining}: "
+        f"{combined['mean_pct']:.2f}% (Δ {combined['mean_pct'] - baseline['mean_pct']:+.2f}pp) "
+        f"argmin_acc {combined['argmin_acc']:.1%}\n"
+    )
+
+    # Persist.
+    out = {
+        "baseline": baseline,
+        "groups": {k: {"features": GROUPS[k], "metrics": v} for k, v in group_results.items()},
+        "combined_loo_drops": {
+            "features_dropped": dropped,
+            "metrics": combined,
+        },
+        "histgb_params": HISTGB_KW,
+    }
+    OUT_JSON.write_text(json.dumps(out, indent=2))
+
+    lines = []
+
+    def w(s):
+        lines.append(s)
+        sys.stderr.write(s + "\n")
+
+    w("\n# Group ablation — Pareto controller HistGB")
+    w(f"Train rows: {len(X_tr)}, val rows: {len(X_va)}")
+    w(f"HistGB: {HISTGB_KW}")
+    w("")
+    w(f"## Baseline (all 19 features)")
+    w(f"mean overhead: {baseline['mean_pct']:.2f}%  argmin_acc: {baseline['argmin_acc']:.1%}")
+    w("")
+    w("## Group ablations (drop each group; sorted by Δ vs baseline)")
+    w(f"{'group':22s} {'n_feats':>7s} {'overhead':>10s} {'Δ vs base':>10s}")
+    w("-" * 60)
+    sorted_groups = sorted(group_results.items(), key=lambda kv: -kv[1]["mean_pct"])
+    for gname, m in sorted_groups:
+        delta = m["mean_pct"] - baseline["mean_pct"]
+        w(f"{gname:22s} {len(GROUPS[gname]):>7d} {m['mean_pct']:>9.2f}%  {delta:>+8.2f}pp")
+    w("")
+    w(f"## Combined LOO-suggested drops ({n_dropped} features dropped)")
+    w(f"dropped: {', '.join(dropped)}")
+    w(
+        f"overhead: {combined['mean_pct']:.2f}% "
+        f"(Δ {combined['mean_pct'] - baseline['mean_pct']:+.2f}pp)  "
+        f"argmin_acc: {combined['argmin_acc']:.1%}"
+    )
+
+    OUT_LOG.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/zenpicker/tools/train_distill.py
+++ b/zenpicker/tools/train_distill.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Distill HistGradientBoosting forest into the small shared MLP.
+
+The HistGB model from `zq_bytes_regression_fit.py` ships at +9.0% mean
+overhead but bakes to ~5-7 MB compressed — too big. The vanilla shared
+MLP from `zq_bytes_mlp_shared.py` bakes to 59 KB but lands at +16.4%
+mean overhead — too noisy.
+
+Distillation uses HistGB's predicted log-bytes as soft targets for the
+MLP. The MLP no longer has to learn the noisy raw byte function; it
+only has to fit HistGB's already-smoothed surface. Same 59 KB artifact,
+much closer to HistGB's accuracy.
+
+Two MLP heads:
+- Standard: trained on HistGB soft targets across all 120 configs
+- Evaluated under all-configs and ycbcr-only masks at argmin time
+
+Inputs:
+- benchmarks/zq_pareto_2026-04-29.tsv
+- benchmarks/zq_pareto_features_2026-04-29.tsv
+
+Outputs:
+- benchmarks/zq_bytes_distill_2026-04-29.{log,json}
+"""
+
+import csv
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.neural_network import MLPRegressor
+from sklearn.preprocessing import StandardScaler
+
+PARETO = Path("benchmarks/zq_pareto_2026-04-29.tsv")
+FEATURES = Path("benchmarks/zq_pareto_features_2026-04-29.tsv")
+OUT_LOG = Path("benchmarks/zq_bytes_distill_2026-04-29.log")
+OUT_JSON = Path("benchmarks/zq_bytes_distill_2026-04-29.json")
+
+ZQ_TARGETS = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC = 0.20
+SEED = 0xCAFE
+
+CONFIG_NAMES: dict = {}
+
+
+def load_pareto(path):
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            CONFIG_NAMES.setdefault(cid, r["config_name"])
+            key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows
+
+
+def load_features(path):
+    feats = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array([float(r[c]) for c in cols], dtype=np.float32)
+    return feats, cols
+
+
+def build_dataset(pareto, feats, feat_cols):
+    """Build (X_simple, X_eng, Y, meta).
+    X_simple: 19 + 4 + 1 + 1 = 25 inputs (for HistGB teacher)
+    X_eng: simple + 4 polynomial + 19 cross terms + 1 icc = 49 (for MLP student)
+    """
+    n_configs = max(CONFIG_NAMES) + 1
+
+    Xs_rows, Xe_rows, Y_rows, meta = [], [], [], []
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        per_cfg = defaultdict(lambda: defaultdict(lambda: math.inf))
+        for s in samples:
+            for zq in ZQ_TARGETS:
+                if s["zensim"] >= zq and s["bytes"] < per_cfg[zq][s["config_id"]]:
+                    per_cfg[zq][s["config_id"]] = s["bytes"]
+
+        for zq in ZQ_TARGETS:
+            cfg_to_bytes = per_cfg[zq]
+            if not cfg_to_bytes:
+                continue
+            zq_norm = zq / 100.0
+            xs = np.concatenate([
+                f, size_oh, np.array([log_px, zq_norm], dtype=np.float32),
+            ])
+            xe = np.concatenate([
+                f, size_oh,
+                np.array([log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px], dtype=np.float32),
+                zq_norm * f,
+                np.array([0.0], dtype=np.float32),  # icc placeholder
+            ])
+            y = np.full(n_configs, np.nan, dtype=np.float32)
+            for cfg, b in cfg_to_bytes.items():
+                if b > 0 and not math.isinf(b):
+                    y[cfg] = math.log(b)
+            Xs_rows.append(xs); Xe_rows.append(xe); Y_rows.append(y); meta.append((image, size, zq))
+
+    return np.stack(Xs_rows), np.stack(Xe_rows), np.stack(Y_rows), meta
+
+
+def evaluate_argmin(Y_pred_log, Y_actual_log, meta, mask, name):
+    n = Y_pred_log.shape[0]
+    overheads = []
+    correct = 0
+    per_zq = defaultdict(list)
+    unreach = 0
+    for i in range(n):
+        actual = Y_actual_log[i]
+        pred = Y_pred_log[i]
+        m = (~np.isnan(actual)) & mask
+        if not np.any(m):
+            unreach += 1
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        # clip to avoid overflow on rough predictions outside training range
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        actual_best = int(np.argmin(ab))
+        pred_best = int(np.argmin(pb))
+        if pred_best == actual_best:
+            correct += 1
+        ov = (ab[pred_best] - ab[actual_best]) / ab[actual_best]
+        overheads.append(ov)
+        per_zq[meta[i][2]].append(ov)
+    if not overheads:
+        return None
+    overheads = np.array(overheads)
+    return {
+        "name": name,
+        "n": int(len(overheads)),
+        "unreachable": unreach,
+        "argmin_accuracy": correct / len(overheads),
+        "overhead_mean_pct": float(100 * np.mean(overheads)),
+        "overhead_p50_pct": float(100 * np.percentile(overheads, 50)),
+        "overhead_p75_pct": float(100 * np.percentile(overheads, 75)),
+        "overhead_p90_pct": float(100 * np.percentile(overheads, 90)),
+        "per_zq": {tz: {
+            "n": len(v), "mean": float(100 * np.mean(v)),
+            "p50": float(100 * np.percentile(v, 50)),
+            "p90": float(100 * np.percentile(v, 90)),
+        } for tz, v in per_zq.items()},
+    }
+
+
+def main():
+    sys.stderr.write(f"Loading {PARETO}...\n")
+    pareto = load_pareto(PARETO)
+    feats, feat_cols = load_features(FEATURES)
+    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features\n")
+
+    Xs, Xe, Y, meta = build_dataset(pareto, feats, feat_cols)
+    n_configs = Y.shape[1]
+    sys.stderr.write(f"Decision rows: {len(Xs)} × {n_configs} configs (Xs:{Xs.shape[1]}, Xe:{Xe.shape[1]})\n")
+
+    rng = np.random.default_rng(SEED)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * HOLDOUT_FRAC))
+    val_set = set(images[:n_val])
+    train_idx = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    val_idx = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    sys.stderr.write(f"Train rows: {len(train_idx)}, val rows: {len(val_idx)}\n")
+
+    Xs_tr, Xs_va = Xs[train_idx], Xs[val_idx]
+    Xe_tr, Xe_va = Xe[train_idx], Xe[val_idx]
+    Y_tr, Y_va = Y[train_idx], Y[val_idx]
+    meta_va = [meta[i] for i in val_idx]
+
+    # ============ Step 1: train HistGB teacher per-config ============
+    sys.stderr.write("\nTraining HistGB teacher (120 per-config models)...\n")
+    teachers = []
+    cfg_means = np.nanmean(Y_tr, axis=0)
+    for cfg in range(n_configs):
+        mask = ~np.isnan(Y_tr[:, cfg])
+        if mask.sum() < 50:
+            teachers.append(None)
+            continue
+        gbm = HistGradientBoostingRegressor(
+            max_iter=400, max_depth=8, learning_rate=0.05,
+            l2_regularization=0.5, random_state=SEED,
+        )
+        gbm.fit(Xs_tr[mask], Y_tr[mask, cfg])
+        teachers.append(gbm)
+        if (cfg + 1) % 20 == 0:
+            sys.stderr.write(f"  {cfg+1}/{n_configs} teachers trained\n")
+
+    # ============ Step 2: generate dense soft targets on full train+val ============
+    sys.stderr.write("\nGenerating soft targets...\n")
+    soft_tr = np.zeros((len(train_idx), n_configs), dtype=np.float32)
+    soft_va = np.zeros((len(val_idx), n_configs), dtype=np.float32)
+    for cfg in range(n_configs):
+        if teachers[cfg] is None:
+            soft_tr[:, cfg] = cfg_means[cfg]
+            soft_va[:, cfg] = cfg_means[cfg]
+        else:
+            soft_tr[:, cfg] = teachers[cfg].predict(Xs_tr)
+            soft_va[:, cfg] = teachers[cfg].predict(Xs_va)
+
+    # Sanity check teacher quality on val
+    all_mask = np.ones(n_configs, dtype=bool)
+    ycbcr_mask = np.array([CONFIG_NAMES[c].startswith("ycbcr") for c in range(n_configs)], dtype=bool)
+    sys.stderr.write("\nTeacher val metrics (sanity check)...\n")
+    t_all = evaluate_argmin(soft_va, Y_va, meta_va, all_mask, "HistGB teacher all")
+    t_ycb = evaluate_argmin(soft_va, Y_va, meta_va, ycbcr_mask, "HistGB teacher ycbcr")
+
+    # ============ Step 3: train MLP student on soft targets ============
+    sys.stderr.write("\nTraining MLP student on HistGB soft targets...\n")
+    scaler = StandardScaler()
+    Xe_tr_s = scaler.fit_transform(Xe_tr)
+    Xe_va_s = scaler.transform(Xe_va)
+    student = MLPRegressor(
+        hidden_layer_sizes=(64, 64),
+        activation="relu",
+        solver="adam",
+        learning_rate_init=2e-3,
+        batch_size=512,
+        max_iter=400,
+        early_stopping=True,
+        validation_fraction=0.1,
+        n_iter_no_change=30,
+        tol=1e-6,
+        random_state=SEED,
+        verbose=False,
+    )
+    student.fit(Xe_tr_s, soft_tr)
+    sys.stderr.write(f"  trained, final loss={student.loss_:.4f}, n_iter={student.n_iter_}\n")
+
+    Y_va_pred = student.predict(Xe_va_s)
+
+    s_all = evaluate_argmin(Y_va_pred, Y_va, meta_va, all_mask, "MLP student all")
+    s_ycb = evaluate_argmin(Y_va_pred, Y_va, meta_va, ycbcr_mask, "MLP student ycbcr")
+
+    # Save weights
+    weights = {
+        "n_inputs": int(Xe.shape[1]),
+        "n_configs": int(n_configs),
+        "config_names": {int(k): v for k, v in CONFIG_NAMES.items()},
+        "feat_cols": feat_cols,
+        "scaler_mean": scaler.mean_.tolist(),
+        "scaler_scale": scaler.scale_.tolist(),
+        "layers": [
+            {"W": w.tolist(), "b": b.tolist()}
+            for w, b in zip(student.coefs_, student.intercepts_)
+        ],
+        "activation": "relu",
+    }
+    OUT_JSON.write_text(json.dumps(weights))
+    n_params = sum(c.size + i.size for c, i in zip(student.coefs_, student.intercepts_))
+    sys.stderr.write(f"  {n_params} weights, {OUT_JSON.stat().st_size} bytes JSON ({n_params*4/1024:.1f} KB f32)\n")
+
+    # Report
+    lines = []
+    def w(s):
+        lines.append(s); sys.stderr.write(s + "\n")
+
+    w("# Distilled MLP — bytes-per-config regression (HistGB teacher → small MLP student)")
+    w(f"Train rows: {len(Xs_tr)}, val rows: {len(Xs_va)}")
+    w(f"Teacher: HistGB per-config × {n_configs}, simple inputs ({Xs.shape[1]})")
+    w(f"Student: MLP {Xe.shape[1]} -> 64 -> 64 -> {n_configs}, engineered inputs, {n_params} params (~{n_params*4/1024:.1f} KB f32)")
+    w("")
+
+    def fmt(m):
+        if m is None: return "n/a"
+        return (f"argmin_acc={m['argmin_accuracy']:.1%}  n={m['n']}  unreach={m['unreachable']}  "
+                f"overhead mean={m['overhead_mean_pct']:+.1f}% "
+                f"p50={m['overhead_p50_pct']:+.1f}% "
+                f"p75={m['overhead_p75_pct']:+.1f}% "
+                f"p90={m['overhead_p90_pct']:+.1f}%")
+
+    w("## Argmin metrics (held-out images)")
+    w(f"HistGB teacher (all):    {fmt(t_all)}")
+    w(f"HistGB teacher (ycbcr):  {fmt(t_ycb)}")
+    w(f"MLP student (all):       {fmt(s_all)}")
+    w(f"MLP student (ycbcr):     {fmt(s_ycb)}")
+    w("")
+
+    for label, m in [("Student all", s_all), ("Student ycbcr-only", s_ycb)]:
+        if m is None: continue
+        w(f"## {label} — per-zq overhead")
+        w("zq  | n   |  mean  |  p50   |  p90   |")
+        w("----|-----|--------|--------|--------|")
+        for tz in sorted(m["per_zq"]):
+            d = m["per_zq"][tz]
+            w(f"{tz:>3} | {d['n']:>3} | {d['mean']:+5.1f}% | {d['p50']:+5.1f}% | {d['p90']:+5.1f}% |")
+        w("")
+
+    OUT_LOG.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/zenpicker/tools/train_distill_reduced.py
+++ b/zenpicker/tools/train_distill_reduced.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+8-feature reduced-schema distillation.
+
+Wraps `zq_bytes_distill.py`'s training pipeline but filters the
+feature columns at load time to the 8-feature picker schema
+validated in `zq_reduced_schema_validate.py`.
+
+The teacher (HistGB per-config × 120, simple inputs) and student
+(shared MLP 64→64→120 with engineered cross-terms) are unchanged.
+Only the input feature column subset differs.
+
+Outputs:
+- benchmarks/zq_bytes_distill_reduced_2026-04-29.json
+- benchmarks/zq_bytes_distill_reduced_2026-04-29.log
+
+The output JSON shape is identical to `zq_bytes_distill.py`'s, so
+`tools/bake_picker.py` consumes it unchanged. The schema_hash will
+differ (different feat_cols, different extra_axes).
+"""
+
+import csv
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.neural_network import MLPRegressor
+from sklearn.preprocessing import StandardScaler
+
+PARETO = Path("benchmarks/zq_pareto_2026-04-29.tsv")
+FEATURES = Path("benchmarks/zq_pareto_features_2026-04-29.tsv")
+OUT_LOG = Path("benchmarks/zq_bytes_distill_reduced_2026-04-29.log")
+OUT_JSON = Path("benchmarks/zq_bytes_distill_reduced_2026-04-29.json")
+
+ZQ_TARGETS = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC = 0.20
+SEED = 0xCAFE
+
+# 8-feature reduced schema (validated 2026-04-29 on production HistGB).
+KEEP_FEATURES = [
+    "feat_variance",
+    "feat_edge_density",
+    "feat_uniformity",
+    "feat_chroma_complexity",
+    "feat_cb_sharpness",
+    "feat_cr_sharpness",
+    "feat_high_freq_energy_ratio",
+    "feat_luma_histogram_entropy",
+]
+
+CONFIG_NAMES: dict = {}
+
+
+def load_pareto(path):
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            CONFIG_NAMES.setdefault(cid, r["config_name"])
+            key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows
+
+
+def load_features(path, keep_set):
+    feats = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        all_cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        # Preserve KEEP_FEATURES order, not the TSV order, so the
+        # baked schema is deterministic and matches what the codec
+        # crate compiles in.
+        ordered_cols = [c for c in KEEP_FEATURES if c in all_cols]
+        missing = [c for c in KEEP_FEATURES if c not in all_cols]
+        if missing:
+            raise SystemExit(f"missing feature columns in TSV: {missing}")
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in ordered_cols], dtype=np.float32
+            )
+    return feats, ordered_cols
+
+
+def build_dataset(pareto, feats, feat_cols):
+    n_configs = max(CONFIG_NAMES) + 1
+    Xs_rows, Xe_rows, Y_rows, meta = [], [], [], []
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        per_cfg = defaultdict(lambda: defaultdict(lambda: math.inf))
+        for s in samples:
+            for zq in ZQ_TARGETS:
+                if s["zensim"] >= zq and s["bytes"] < per_cfg[zq][s["config_id"]]:
+                    per_cfg[zq][s["config_id"]] = s["bytes"]
+
+        for zq in ZQ_TARGETS:
+            cfg_to_bytes = per_cfg[zq]
+            if not cfg_to_bytes:
+                continue
+            zq_norm = zq / 100.0
+            xs = np.concatenate([f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)])
+            xe = np.concatenate([
+                f, size_oh,
+                np.array([log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px], dtype=np.float32),
+                zq_norm * f,
+                np.array([0.0], dtype=np.float32),  # icc placeholder
+            ])
+            y = np.full(n_configs, np.nan, dtype=np.float32)
+            for cfg, b in cfg_to_bytes.items():
+                if b > 0 and not math.isinf(b):
+                    y[cfg] = math.log(b)
+            Xs_rows.append(xs); Xe_rows.append(xe); Y_rows.append(y); meta.append((image, size, zq))
+    return np.stack(Xs_rows), np.stack(Xe_rows), np.stack(Y_rows), meta
+
+
+def evaluate_argmin(Y_pred_log, Y_actual_log, meta, mask, name):
+    n = Y_pred_log.shape[0]
+    overheads = []
+    correct = 0
+    per_zq = defaultdict(list)
+    unreach = 0
+    for i in range(n):
+        actual = Y_actual_log[i]
+        pred = Y_pred_log[i]
+        m = (~np.isnan(actual)) & mask
+        if not np.any(m):
+            unreach += 1
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        actual_best = int(np.argmin(ab))
+        pred_best = int(np.argmin(pb))
+        if pred_best == actual_best:
+            correct += 1
+        ov = (ab[pred_best] - ab[actual_best]) / ab[actual_best]
+        overheads.append(ov)
+        per_zq[meta[i][2]].append(ov)
+    arr = np.array(overheads)
+    return {
+        "name": name,
+        "n": int(len(arr)),
+        "unreachable": unreach,
+        "argmin_accuracy": correct / len(arr),
+        "overhead_mean_pct": float(100 * arr.mean()),
+        "overhead_p50_pct": float(100 * np.percentile(arr, 50)),
+        "overhead_p75_pct": float(100 * np.percentile(arr, 75)),
+        "overhead_p90_pct": float(100 * np.percentile(arr, 90)),
+    }
+
+
+def main():
+    sys.stderr.write(f"Loading {PARETO}...\n")
+    pareto = load_pareto(PARETO)
+    feats, feat_cols = load_features(FEATURES, set(KEEP_FEATURES))
+    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features (reduced schema)\n")
+    sys.stderr.write(f"  feat_cols: {feat_cols}\n")
+
+    Xs, Xe, Y, meta = build_dataset(pareto, feats, feat_cols)
+    n_configs = Y.shape[1]
+    sys.stderr.write(f"Decision rows: {len(Xs)} × {n_configs} configs (Xs:{Xs.shape[1]}, Xe:{Xe.shape[1]})\n")
+
+    rng = np.random.default_rng(SEED)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * HOLDOUT_FRAC))
+    val_set = set(images[:n_val])
+    train_idx = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    val_idx = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    sys.stderr.write(f"Train rows: {len(train_idx)}, val rows: {len(val_idx)}\n")
+
+    Xs_tr, Xs_va = Xs[train_idx], Xs[val_idx]
+    Xe_tr, Xe_va = Xe[train_idx], Xe[val_idx]
+    Y_tr, Y_va = Y[train_idx], Y[val_idx]
+    meta_va = [meta[i] for i in val_idx]
+
+    sys.stderr.write("\nTraining HistGB teacher (120 per-config models)...\n")
+    teachers = []
+    cfg_means = np.nanmean(Y_tr, axis=0)
+    for cfg in range(n_configs):
+        mask = ~np.isnan(Y_tr[:, cfg])
+        if mask.sum() < 50:
+            teachers.append(None)
+            continue
+        gbm = HistGradientBoostingRegressor(
+            max_iter=400, max_depth=8, learning_rate=0.05,
+            l2_regularization=0.5, random_state=SEED,
+        )
+        gbm.fit(Xs_tr[mask], Y_tr[mask, cfg])
+        teachers.append(gbm)
+        if (cfg + 1) % 30 == 0:
+            sys.stderr.write(f"  {cfg+1}/{n_configs} teachers trained\n")
+
+    sys.stderr.write("\nGenerating soft targets...\n")
+    soft_tr = np.zeros((len(train_idx), n_configs), dtype=np.float32)
+    soft_va = np.zeros((len(val_idx), n_configs), dtype=np.float32)
+    for cfg in range(n_configs):
+        if teachers[cfg] is None:
+            soft_tr[:, cfg] = cfg_means[cfg]
+            soft_va[:, cfg] = cfg_means[cfg]
+        else:
+            soft_tr[:, cfg] = teachers[cfg].predict(Xs_tr)
+            soft_va[:, cfg] = teachers[cfg].predict(Xs_va)
+
+    all_mask = np.ones(n_configs, dtype=bool)
+    sys.stderr.write("\nTeacher val metrics (sanity check)...\n")
+    t_all = evaluate_argmin(soft_va, Y_va, meta_va, all_mask, "HistGB teacher")
+
+    sys.stderr.write("\nTraining MLP student on HistGB soft targets...\n")
+    scaler = StandardScaler()
+    Xe_tr_s = scaler.fit_transform(Xe_tr)
+    Xe_va_s = scaler.transform(Xe_va)
+    student = MLPRegressor(
+        hidden_layer_sizes=(64, 64),
+        activation="relu",
+        solver="adam",
+        learning_rate_init=2e-3,
+        batch_size=512,
+        max_iter=400,
+        early_stopping=True,
+        validation_fraction=0.1,
+        n_iter_no_change=30,
+        tol=1e-6,
+        random_state=SEED,
+        verbose=False,
+    )
+    student.fit(Xe_tr_s, soft_tr)
+    sys.stderr.write(f"  trained, final loss={student.loss_:.4f}, n_iter={student.n_iter_}\n")
+
+    Y_va_pred = student.predict(Xe_va_s)
+    s_all = evaluate_argmin(Y_va_pred, Y_va, meta_va, all_mask, "MLP student")
+
+    weights = {
+        "n_inputs": int(Xe.shape[1]),
+        "n_configs": int(n_configs),
+        "config_names": {int(k): v for k, v in CONFIG_NAMES.items()},
+        "feat_cols": feat_cols,
+        "scaler_mean": scaler.mean_.tolist(),
+        "scaler_scale": scaler.scale_.tolist(),
+        "layers": [
+            {"W": w.tolist(), "b": b.tolist()}
+            for w, b in zip(student.coefs_, student.intercepts_)
+        ],
+        "activation": "relu",
+    }
+    OUT_JSON.write_text(json.dumps(weights))
+    n_params = sum(c.size + i.size for c, i in zip(student.coefs_, student.intercepts_))
+    sys.stderr.write(f"  {n_params} weights, {OUT_JSON.stat().st_size} bytes JSON ({n_params*4/1024:.1f} KB f32)\n")
+
+    lines = []
+
+    def w(s):
+        lines.append(s); sys.stderr.write(s + "\n")
+
+    w("\n# Distilled MLP — 8-feature reduced schema")
+    w(f"Train rows: {len(Xs_tr)}, val rows: {len(Xs_va)}")
+    w(f"Teacher: HistGB per-config × {n_configs}, simple inputs ({Xs.shape[1]}: {len(feat_cols)} feats + 4 size + log_px + zq)")
+    w(f"Student: MLP {Xe.shape[1]} -> 64 -> 64 -> {n_configs}, engineered inputs, {n_params} params (~{n_params*4/1024:.1f} KB f32)")
+    w("")
+
+    def fmt(m):
+        return (f"argmin_acc={m['argmin_accuracy']:.1%}  n={m['n']}  unreach={m['unreachable']}  "
+                f"overhead mean={m['overhead_mean_pct']:+.1f}% "
+                f"p50={m['overhead_p50_pct']:+.1f}% "
+                f"p75={m['overhead_p75_pct']:+.1f}% "
+                f"p90={m['overhead_p90_pct']:+.1f}%")
+
+    w("## Argmin metrics (held-out images, all configs allowed)")
+    w(f"HistGB teacher: {fmt(t_all)}")
+    w(f"MLP student:    {fmt(s_all)}")
+    w("")
+    w(f"## Features kept ({len(feat_cols)})")
+    for c in feat_cols:
+        w(f"  {c}")
+
+    OUT_LOG.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/zenpicker/tools/train_hybrid.py
+++ b/zenpicker/tools/train_hybrid.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""
+Hybrid-heads picker training — codec-agnostic in shape.
+
+Splits the codec's full config grid into:
+  - N categorical cells (some combination of discrete-only axes:
+    color_mode, subsampling, trellis_on/off, sa_piecewise, …)
+  - K continuous predictions per cell (e.g. chroma_scale, lambda,
+    effort) extracted from the within-cell-optimal config
+
+For each (image, size, target_zq), compute the within-cell optimal:
+  bytes(cell)        = min bytes over configs in cell that reach zq
+  scalar_<i>(cell)   = scalar value of the within-cell optimal config
+
+Train an MLP with `(K + 1) × N` outputs:
+  bytes head:   N log-bytes outputs  (categorical pick target)
+  scalar heads: N×K continuous outputs
+
+At inference:
+  Y = picker.predict(features)
+  bytes_log = Y[0..N]
+  scalar_<i> = Y[N*(i+1) .. N*(i+2)]   for i in 0..K
+  cell_idx = argmin(bytes_log, mask=allowed_cells)
+  encoder_config = build_from(CELLS[cell_idx], scalar_<i>[cell_idx], …)
+
+The model learns *Pareto-optimal scalars* per cell. The codec
+consumer clamps to caller constraints at inference.
+
+# Codec-side adapter
+
+The codec supplies one Python module that exports:
+
+    PARETO          — Path to the Pareto sweep TSV
+    FEATURES        — Path to the analyzer features TSV
+    OUT_JSON        — Output path for the trained model JSON
+    OUT_LOG         — Output path for the training summary
+    KEEP_FEATURES   — list[str] of `feat_*` column names to use
+    ZQ_TARGETS      — list[int] of target_zq values to model
+    parse_config_name(name: str) -> dict
+        Returns a dict with at least:
+          - one or more `categorical_axes` (hashable values)
+          - one or more `scalar_axes` (float values; sentinel for
+            "not applicable" cells, e.g. lambda=0 in noT cells)
+
+Run with:
+    python3 train_hybrid.py --codec-config zenjpeg_picker_config
+
+A reference codec config lives at `examples/zenjpeg_picker_config.py`.
+"""
+
+import argparse
+import csv
+import importlib
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.neural_network import MLPRegressor
+from sklearn.preprocessing import StandardScaler
+
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC = 0.20
+SEED = 0xCAFE
+
+CONFIG_NAMES: dict = {}
+
+# These are bound from the loaded codec config in main(). Module-
+# level placeholders so the helper functions below can name them.
+PARETO: Path
+FEATURES: Path
+OUT_LOG: Path
+OUT_JSON: Path
+ZQ_TARGETS: list
+KEEP_FEATURES: list
+parse_config_name = None  # type: ignore[assignment]
+
+
+def load_codec_config(name: str):
+    """Import a codec-config module and bind its exports to module-level
+    names this script consumes. The codec module must define:
+      PARETO, FEATURES, OUT_JSON, OUT_LOG, ZQ_TARGETS, KEEP_FEATURES,
+      parse_config_name(name: str) -> dict.
+
+    `parse_config_name` returns a dict whose keys partition into:
+      - categorical axes (hashable values, used to form cells via
+        `categorical_key()`)
+      - scalar axes (float values; sentinel allowed for "not
+        applicable" — e.g. lambda=0.0 in trellis-off cells)
+
+    The `categorical_key` and the scalar-axis list are determined by
+    the codec config; this script reads them via the codec's
+    `CATEGORICAL_AXES` and `SCALAR_AXES` constants when present.
+    """
+    global PARETO, FEATURES, OUT_LOG, OUT_JSON
+    global ZQ_TARGETS, KEEP_FEATURES, parse_config_name
+    mod = importlib.import_module(name)
+    PARETO = Path(mod.PARETO)
+    FEATURES = Path(mod.FEATURES)
+    OUT_LOG = Path(mod.OUT_LOG)
+    OUT_JSON = Path(mod.OUT_JSON)
+    ZQ_TARGETS = list(mod.ZQ_TARGETS)
+    KEEP_FEATURES = list(mod.KEEP_FEATURES)
+    parse_config_name = mod.parse_config_name
+    return mod
+
+
+# ---------- Config-name parser (codec-supplied) ----------
+#
+# `parse_config_name` is bound by `load_codec_config()`. The codec
+# config module owns the regex/pattern that parses its own
+# config-name convention into a dict of categorical + scalar axes.
+# See `examples/zenjpeg_picker_config.py` for a reference.
+#
+# (Intentionally empty — function lives in the codec config.)
+
+
+def _placeholder_parse_config_name(name: str) -> dict:
+    """Stub returning the same shape as `parse_config_name` would.
+    Only here so static analysis can see the contract; never called.
+    """
+    return {
+        "color": "",
+        "sub": "",
+        "sa": False,
+        "trellis_on": False,
+        "lambda": 0.0,
+        "chroma_scale": 0.0,
+    }
+
+
+def categorical_key(parsed: dict) -> tuple:
+    """The (color, sub, trellis_on, sa) tuple. xyb cells always have sa=False."""
+    return (parsed["color"], parsed["sub"], parsed["trellis_on"], parsed["sa"])
+
+
+# ---------- Data loading ----------
+
+
+def load_pareto(path):
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            CONFIG_NAMES.setdefault(cid, r["config_name"])
+            key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows
+
+
+def load_features(path):
+    feats = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        all_cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        cols = [c for c in KEEP_FEATURES if c in all_cols]
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in cols], dtype=np.float32
+            )
+    return feats, cols
+
+
+# ---------- Build categorical cell mapping ----------
+
+
+def build_cell_index():
+    """Return:
+       cells: list of dicts describing each cell (in stable order)
+       cell_id_by_key: {(color, sub, trellis_on, sa) -> int}
+       config_to_cell: {config_id -> cell_id}
+       config_to_parsed: {config_id -> parsed dict}
+    """
+    parsed_all = {}
+    for cid, name in CONFIG_NAMES.items():
+        parsed_all[cid] = parse_config_name(name)
+
+    keys = sorted({categorical_key(p) for p in parsed_all.values()})
+    cell_id_by_key = {k: i for i, k in enumerate(keys)}
+
+    cells = []
+    for k in keys:
+        color, sub, trellis_on, sa = k
+        # Pick a representative human-readable label
+        sa_tag = "_sa" if sa else ""
+        trel_tag = "trellis" if trellis_on else "noT"
+        label = f"{color}_{sub}_{trel_tag}{sa_tag}"
+        # Find member configs
+        members = [cid for cid, p in parsed_all.items() if categorical_key(p) == k]
+        cells.append(
+            {
+                "id": cell_id_by_key[k],
+                "label": label,
+                "color": color,
+                "sub": sub,
+                "trellis_on": trellis_on,
+                "sa": sa,
+                "member_config_ids": sorted(members),
+            }
+        )
+
+    config_to_cell = {cid: cell_id_by_key[categorical_key(p)] for cid, p in parsed_all.items()}
+    return cells, cell_id_by_key, config_to_cell, parsed_all
+
+
+# ---------- Build training dataset ----------
+
+
+def build_dataset(pareto, feats, feat_cols, cells, config_to_cell, parsed_all):
+    """Per (image, size, zq) row, compute within-cell optimal:
+       bytes_log[c]    = log(min bytes in cell c over configs that reach zq)
+       chroma_scale[c] = chroma of the within-cell optimal
+       lambda[c]       = lambda of the within-cell optimal
+       reachable[c]    = 1 if any config in cell c reached zq, 0 otherwise
+    """
+    n_cells = len(cells)
+    Xs_rows, Xe_rows = [], []
+    bytes_log_rows, chroma_rows, lambda_rows, reach_rows = [], [], [], []
+    meta = []
+
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        # Group samples by config to track per-config best.
+        # (one config can have multiple q values; pareto-best for each
+        # cell at each zq target is the cheapest config that crosses zq.)
+        by_cfg = defaultdict(list)
+        for s in samples:
+            by_cfg[s["config_id"]].append(s)
+
+        for zq in ZQ_TARGETS:
+            cell_bytes = [math.inf] * n_cells
+            cell_cs = [math.nan] * n_cells
+            cell_lam = [math.nan] * n_cells
+            cell_reach = [False] * n_cells
+
+            for cfg_id, hits in by_cfg.items():
+                # Cheapest sample for this config that reaches zq.
+                best_b = math.inf
+                for s in hits:
+                    if s["zensim"] >= zq and s["bytes"] < best_b:
+                        best_b = s["bytes"]
+                if math.isinf(best_b):
+                    continue
+                c = config_to_cell[cfg_id]
+                if best_b < cell_bytes[c]:
+                    cell_bytes[c] = best_b
+                    p = parsed_all[cfg_id]
+                    cell_cs[c] = p["chroma_scale"]
+                    cell_lam[c] = p["lambda"]
+                    cell_reach[c] = True
+
+            if not any(cell_reach):
+                continue
+
+            zq_norm = zq / 100.0
+            # Engineered input vector — same as v1.1 student to keep
+            # the comparison apples-to-apples.
+            xs = np.concatenate([f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)])
+            xe = np.concatenate([
+                f,
+                size_oh,
+                np.array(
+                    [log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px],
+                    dtype=np.float32,
+                ),
+                zq_norm * f,
+                np.array([0.0], dtype=np.float32),  # icc placeholder
+            ])
+
+            bytes_log = np.array(
+                [math.log(b) if not math.isinf(b) else math.nan for b in cell_bytes],
+                dtype=np.float32,
+            )
+            chroma = np.array(cell_cs, dtype=np.float32)
+            lam = np.array(cell_lam, dtype=np.float32)
+            reach = np.array(cell_reach, dtype=bool)
+
+            Xs_rows.append(xs)
+            Xe_rows.append(xe)
+            bytes_log_rows.append(bytes_log)
+            chroma_rows.append(chroma)
+            lambda_rows.append(lam)
+            reach_rows.append(reach)
+            meta.append((image, size, zq))
+
+    return (
+        np.stack(Xs_rows),
+        np.stack(Xe_rows),
+        np.stack(bytes_log_rows),
+        np.stack(chroma_rows),
+        np.stack(lambda_rows),
+        np.stack(reach_rows),
+        meta,
+    )
+
+
+# ---------- Evaluation ----------
+
+
+def evaluate_argmin(pred_bytes_log, actual_bytes_log, reach, meta, mask):
+    """Categorical argmin over allowed reachable cells."""
+    n_rows = pred_bytes_log.shape[0]
+    overheads, correct = [], 0
+    for i in range(n_rows):
+        actual = actual_bytes_log[i]
+        pred = pred_bytes_log[i]
+        m = reach[i] & mask
+        if not np.any(m):
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        a = int(np.argmin(ab))
+        p = int(np.argmin(pb))
+        if p == a:
+            correct += 1
+        overheads.append((ab[p] - ab[a]) / ab[a])
+    arr = np.array(overheads)
+    return {
+        "n": int(len(arr)),
+        "argmin_acc": correct / len(arr),
+        "mean_pct": float(100 * arr.mean()),
+        "p50_pct": float(100 * np.percentile(arr, 50)),
+        "p90_pct": float(100 * np.percentile(arr, 90)),
+    }
+
+
+def evaluate_scalars(pred_chroma, actual_chroma, pred_lam, actual_lam, reach):
+    """RMSE on the chroma_scale and lambda predictions, computed over
+    reachable cells only (where the targets exist).
+    """
+    rmse = {}
+    cs_diff = []
+    lam_diff = []
+    for i in range(pred_chroma.shape[0]):
+        for c in range(pred_chroma.shape[1]):
+            if not reach[i, c]:
+                continue
+            cs_diff.append(pred_chroma[i, c] - actual_chroma[i, c])
+            # lambda only meaningful when trellis_on (target != sentinel)
+            if not math.isnan(actual_lam[i, c]) and actual_lam[i, c] > 0:
+                lam_diff.append(pred_lam[i, c] - actual_lam[i, c])
+    cs_arr = np.array(cs_diff, dtype=np.float64)
+    lam_arr = np.array(lam_diff, dtype=np.float64) if lam_diff else np.array([0.0])
+    rmse["chroma_scale"] = float(np.sqrt((cs_arr ** 2).mean()))
+    rmse["chroma_scale_mae"] = float(np.abs(cs_arr).mean())
+    rmse["lambda"] = float(np.sqrt((lam_arr ** 2).mean()))
+    rmse["lambda_mae"] = float(np.abs(lam_arr).mean())
+    return rmse
+
+
+# ---------- Train ----------
+
+
+def train_teacher_per_cell(Xs_tr, bytes_log_tr, chroma_tr, lam_tr, reach_tr, n_cells, params=None):
+    """Per-cell HistGB regressors for: bytes_log, chroma_scale, lambda.
+
+    Three teachers per cell × 12 cells × ~5 s each = ~3 min serial.
+    With `train_teachers_per_cell_parallel` from `_zq_picker_lib.py`
+    on a 16-core box, drops to ~30 s × 3 = ~90 s. ~12× speedup vs the
+    pre-2026-04-29 serial loop.
+
+    `params` defaults to `HISTGB_FULL` (production training). Pass
+    `HISTGB_FAST` for iteration / ablation runs.
+    """
+    from _picker_lib import HISTGB_FULL, train_teachers_per_cell_parallel
+
+    if params is None:
+        params = HISTGB_FULL
+
+    cs_means = np.nanmean(chroma_tr, axis=0)
+    lam_means = np.nanmean(np.where(lam_tr > 0, lam_tr, np.nan), axis=0)
+
+    # Bytes head — per-cell reach mask (cell achieved target_zq).
+    teachers_bytes = train_teachers_per_cell_parallel(
+        Xs_tr, bytes_log_tr, reach_tr, params=params, label="bytes"
+    )
+
+    # Chroma head — same reach mask (chroma_scale only meaningful
+    # when the cell actually reaches target).
+    teachers_chroma = train_teachers_per_cell_parallel(
+        Xs_tr, chroma_tr, reach_tr, params=params, label="chroma"
+    )
+
+    # Lambda head — additional mask: lambda > 0 (trellis-on rows
+    # only). noT cells will fall through to the < 50 row check
+    # inside the worker and return None.
+    lambda_extra_mask = lam_tr > 0
+    teachers_lambda = train_teachers_per_cell_parallel(
+        Xs_tr, lam_tr, reach_tr, extra_mask=lambda_extra_mask, params=params, label="lambda"
+    )
+
+    return teachers_bytes, teachers_chroma, teachers_lambda, cs_means, lam_means
+
+
+def teacher_predict_all(teachers, Xs, fallback_means, n_cells):
+    out = np.zeros((Xs.shape[0], n_cells), dtype=np.float32)
+    for c in range(n_cells):
+        if teachers[c] is None:
+            out[:, c] = fallback_means[c] if not math.isnan(fallback_means[c]) else 0.0
+        else:
+            out[:, c] = teachers[c].predict(Xs)
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--codec-config",
+        required=True,
+        help="Python module name exporting PARETO/FEATURES/OUT_*/ZQ_TARGETS/"
+        "KEEP_FEATURES/parse_config_name. Example: zenjpeg_picker_config (which "
+        "must be importable on PYTHONPATH).",
+    )
+    args = parser.parse_args()
+    load_codec_config(args.codec_config)
+
+    sys.stderr.write(f"Loading {PARETO}...\n")
+    pareto = load_pareto(PARETO)
+    feats, feat_cols = load_features(FEATURES)
+    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features\n")
+
+    cells, cell_id_by_key, config_to_cell, parsed_all = build_cell_index()
+    n_cells = len(cells)
+    sys.stderr.write(f"\nCategorical cells: {n_cells}\n")
+    for c in cells:
+        sys.stderr.write(f"  {c['id']:>2d}: {c['label']:30s}  ({len(c['member_config_ids'])} configs)\n")
+
+    Xs, Xe, bytes_log, chroma, lam, reach, meta = build_dataset(
+        pareto, feats, feat_cols, cells, config_to_cell, parsed_all
+    )
+    sys.stderr.write(
+        f"\nDecision rows: {len(Xs)}; Xs={Xs.shape[1]}, Xe={Xe.shape[1]}, n_cells={n_cells}\n"
+    )
+
+    rng = np.random.default_rng(SEED)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * HOLDOUT_FRAC))
+    val_set = set(images[:n_val])
+    tr = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    va = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    sys.stderr.write(f"Train rows: {len(tr)}, val rows: {len(va)}\n")
+
+    Xs_tr, Xs_va = Xs[tr], Xs[va]
+    Xe_tr, Xe_va = Xe[tr], Xe[va]
+    bl_tr, bl_va = bytes_log[tr], bytes_log[va]
+    cs_tr, cs_va = chroma[tr], chroma[va]
+    lam_tr, lam_va = lam[tr], lam[va]
+    rch_tr, rch_va = reach[tr], reach[va]
+    meta_va = [meta[i] for i in va]
+
+    # --- Teacher
+    t_bytes, t_chroma, t_lambda, cs_means, lam_means = train_teacher_per_cell(
+        Xs_tr, bl_tr, cs_tr, lam_tr, rch_tr, n_cells
+    )
+    sys.stderr.write("\nGenerating teacher soft targets (val + train)...\n")
+    bytes_pred_tr = teacher_predict_all(t_bytes, Xs_tr, np.nanmean(bl_tr, axis=0), n_cells)
+    bytes_pred_va = teacher_predict_all(t_bytes, Xs_va, np.nanmean(bl_tr, axis=0), n_cells)
+    chroma_pred_tr = teacher_predict_all(t_chroma, Xs_tr, cs_means, n_cells)
+    chroma_pred_va = teacher_predict_all(t_chroma, Xs_va, cs_means, n_cells)
+    lam_pred_tr = teacher_predict_all(t_lambda, Xs_tr, lam_means, n_cells)
+    lam_pred_va = teacher_predict_all(t_lambda, Xs_va, lam_means, n_cells)
+
+    all_mask = np.ones(n_cells, dtype=bool)
+    teacher_argmin = evaluate_argmin(bytes_pred_va, bl_va, rch_va, meta_va, all_mask)
+    teacher_scalars = evaluate_scalars(chroma_pred_va, cs_va, lam_pred_va, lam_va, rch_va)
+    sys.stderr.write(
+        f"\nTeacher metrics: argmin mean overhead {teacher_argmin['mean_pct']:.2f}% "
+        f"argmin_acc {teacher_argmin['argmin_acc']:.1%}\n"
+    )
+    sys.stderr.write(
+        f"  scalar RMSE: chroma {teacher_scalars['chroma_scale']:.4f}  "
+        f"lambda {teacher_scalars['lambda']:.3f}\n"
+    )
+
+    # --- Student
+    # Soft targets: 12 bytes + 12 chroma + 12 lambda = 36 outputs
+    soft_tr = np.concatenate([bytes_pred_tr, chroma_pred_tr, lam_pred_tr], axis=1)
+    sys.stderr.write(f"\nTraining MLP student (hidden=128x2, output_dim={soft_tr.shape[1]})...\n")
+
+    scaler = StandardScaler()
+    Xe_tr_s = scaler.fit_transform(Xe_tr)
+    Xe_va_s = scaler.transform(Xe_va)
+    student = MLPRegressor(
+        hidden_layer_sizes=(128, 128),
+        activation="relu",
+        solver="adam",
+        learning_rate_init=2e-3,
+        batch_size=512,
+        max_iter=500,
+        early_stopping=True,
+        validation_fraction=0.1,
+        n_iter_no_change=30,
+        tol=1e-6,
+        random_state=SEED,
+        verbose=False,
+    )
+    student.fit(Xe_tr_s, soft_tr)
+    sys.stderr.write(f"  trained, final loss={student.loss_:.4f}, n_iter={student.n_iter_}\n")
+
+    Y_va_pred = student.predict(Xe_va_s)
+    pred_bytes = Y_va_pred[:, :n_cells]
+    pred_chroma = Y_va_pred[:, n_cells : 2 * n_cells]
+    pred_lambda = Y_va_pred[:, 2 * n_cells : 3 * n_cells]
+
+    student_argmin = evaluate_argmin(pred_bytes, bl_va, rch_va, meta_va, all_mask)
+    student_scalars = evaluate_scalars(pred_chroma, cs_va, pred_lambda, lam_va, rch_va)
+    sys.stderr.write(
+        f"\nStudent metrics: argmin mean overhead {student_argmin['mean_pct']:.2f}% "
+        f"argmin_acc {student_argmin['argmin_acc']:.1%}\n"
+    )
+    sys.stderr.write(
+        f"  scalar RMSE: chroma {student_scalars['chroma_scale']:.4f}  "
+        f"lambda {student_scalars['lambda']:.3f}\n"
+    )
+
+    # --- Persist
+    n_params = sum(c.size + i.size for c, i in zip(student.coefs_, student.intercepts_))
+    out = {
+        "n_inputs": int(Xe.shape[1]),
+        "n_outputs": 3 * n_cells,
+        "n_cells": n_cells,
+        "config_names": {int(k): v for k, v in CONFIG_NAMES.items()},
+        "feat_cols": feat_cols,
+        "scaler_mean": scaler.mean_.tolist(),
+        "scaler_scale": scaler.scale_.tolist(),
+        "layers": [
+            {"W": w.tolist(), "b": b.tolist()}
+            for w, b in zip(student.coefs_, student.intercepts_)
+        ],
+        "activation": "relu",
+        "hybrid_heads_manifest": {
+            "n_cells": n_cells,
+            "cells": cells,
+            "output_layout": {
+                "bytes_log": [0, n_cells],
+                "chroma_scale": [n_cells, 2 * n_cells],
+                "lambda": [2 * n_cells, 3 * n_cells],
+            },
+            "lambda_notrellis_sentinel": getattr(
+                sys.modules.get(parse_config_name.__module__, sys.modules[__name__]),
+                "LAMBDA_NOTRELLIS_SENTINEL",
+                0.0,
+            ),
+        },
+        "teacher_metrics": {"argmin": teacher_argmin, "scalars": teacher_scalars},
+        "student_metrics": {"argmin": student_argmin, "scalars": student_scalars},
+    }
+    OUT_JSON.write_text(json.dumps(out, indent=2))
+    sys.stderr.write(
+        f"\nWrote {OUT_JSON} ({n_params} weights, {n_params*2/1024:.1f} KB f16)\n"
+    )
+
+    # --- Report
+    lines = []
+    def w(s):
+        lines.append(s)
+        sys.stderr.write(s + "\n")
+
+    w("\n# Hybrid-heads picker — categorical bytes + scalar (chroma_scale, lambda)")
+    w(f"Train rows: {len(tr)}, val rows: {len(va)}")
+    w(f"n_cells: {n_cells}, output_dim: {3 * n_cells}")
+    w(f"Student: MLP {Xe.shape[1]} -> 128 -> 128 -> {3 * n_cells}, "
+      f"{n_params} params (~{n_params*2/1024:.1f} KB f16)")
+    w("")
+    w("## Categorical cells")
+    for c in cells:
+        w(f"  {c['id']:>2d}: {c['label']:30s}  ({len(c['member_config_ids'])} member configs)")
+    w("")
+    w("## Argmin (categorical) — vs reachable per-row optimal")
+    w(f"  Teacher: mean {teacher_argmin['mean_pct']:.2f}%  argmin_acc {teacher_argmin['argmin_acc']:.1%}")
+    w(f"  Student: mean {student_argmin['mean_pct']:.2f}%  argmin_acc {student_argmin['argmin_acc']:.1%}")
+    w("")
+    w("## Scalar regression RMSE")
+    w(f"  Teacher chroma_scale RMSE: {teacher_scalars['chroma_scale']:.4f}  "
+      f"(MAE {teacher_scalars['chroma_scale_mae']:.4f}, range 0.6..1.5)")
+    w(f"  Teacher lambda RMSE:       {teacher_scalars['lambda']:.3f}   "
+      f"(MAE {teacher_scalars['lambda_mae']:.3f}, range 8..25)")
+    w(f"  Student chroma_scale RMSE: {student_scalars['chroma_scale']:.4f}  "
+      f"(MAE {student_scalars['chroma_scale_mae']:.4f})")
+    w(f"  Student lambda RMSE:       {student_scalars['lambda']:.3f}   "
+      f"(MAE {student_scalars['lambda_mae']:.3f})")
+
+    OUT_LOG.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/zenpicker/tools/validate_schema.py
+++ b/zenpicker/tools/validate_schema.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Validate the 8-feature reduced schema on production HistGB.
+
+The ablation work used a lighter HistGB (max_iter=100, max_depth=4)
+for throughput across 19 LOO + 5 group + 4 sub-ablation points. The
+ranking should be stable but absolute numbers shift. This script
+re-runs at production hyperparameters (max_iter=400, max_depth=8 —
+matching zq_bytes_distill.py's teacher) on:
+
+  baseline (all 19 features)  — should reproduce ~6.8% mean overhead
+  reduced  (8 features)       — must be ≤ baseline to ship
+
+Reduced schema (8 features kept):
+  Tier 1 basic:  variance, edge_density, uniformity, chroma_complexity
+  Tier 1 chroma: cb_sharpness, cr_sharpness
+  Tier 3 DCT:    high_freq_energy_ratio, luma_histogram_entropy
+
+Dropped (11 features, 3 entire zenanalyze tiers):
+  Alpha tier (3): alpha_present, alpha_used_fraction, alpha_bimodal_score
+  Palette tier (2): distinct_color_bins, flat_color_block_ratio
+  Tier 2 (6): cb/cr × {horiz, vert, peak}_sharpness
+
+Output: benchmarks/zq_reduced_schema_validate_2026-04-29.{log,json}
+"""
+
+import csv
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+PARETO = Path("benchmarks/zq_pareto_2026-04-29.tsv")
+FEATURES = Path("benchmarks/zq_pareto_features_2026-04-29.tsv")
+OUT_LOG = Path("benchmarks/zq_reduced_schema_validate_2026-04-29.log")
+OUT_JSON = Path("benchmarks/zq_reduced_schema_validate_2026-04-29.json")
+
+ZQ_TARGETS = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC = 0.20
+SEED = 0xCAFE
+
+# Production HistGB hyperparameters — same as zq_bytes_distill.py teacher.
+HISTGB_KW = dict(
+    max_iter=400,
+    max_depth=8,
+    learning_rate=0.05,
+    l2_regularization=0.5,
+    random_state=SEED,
+)
+
+KEEP_FEATURES = [
+    "feat_variance",
+    "feat_edge_density",
+    "feat_uniformity",
+    "feat_chroma_complexity",
+    "feat_cb_sharpness",
+    "feat_cr_sharpness",
+    "feat_high_freq_energy_ratio",
+    "feat_luma_histogram_entropy",
+]
+
+CONFIG_NAMES: dict = {}
+
+
+def load_pareto(path):
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            CONFIG_NAMES.setdefault(cid, r["config_name"])
+            key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows
+
+
+def load_features(path):
+    feats = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in cols], dtype=np.float32
+            )
+    return feats, cols
+
+
+def build_dataset(pareto, feats, feat_cols):
+    n_configs = max(CONFIG_NAMES) + 1
+    X_rows, Y_rows, meta = [], [], []
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        per_cfg = defaultdict(lambda: defaultdict(lambda: math.inf))
+        for s in samples:
+            for zq in ZQ_TARGETS:
+                if s["zensim"] >= zq and s["bytes"] < per_cfg[zq][s["config_id"]]:
+                    per_cfg[zq][s["config_id"]] = s["bytes"]
+
+        for zq in ZQ_TARGETS:
+            if not per_cfg[zq]:
+                continue
+            zq_norm = zq / 100.0
+            x = np.concatenate([f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)])
+            y = np.full(n_configs, np.nan, dtype=np.float32)
+            for cfg, b in per_cfg[zq].items():
+                if b > 0 and not math.isinf(b):
+                    y[cfg] = math.log(b)
+            X_rows.append(x)
+            Y_rows.append(y)
+            meta.append((image, size, zq))
+    return np.stack(X_rows), np.stack(Y_rows), meta
+
+
+def evaluate(Y_pred, Y_actual, meta):
+    overheads, correct = [], 0
+    per_zq = defaultdict(list)
+    for i in range(Y_pred.shape[0]):
+        actual = Y_actual[i]
+        pred = Y_pred[i]
+        m = ~np.isnan(actual)
+        if not np.any(m):
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        a = int(np.argmin(ab))
+        p = int(np.argmin(pb))
+        if p == a:
+            correct += 1
+        ov = (ab[p] - ab[a]) / ab[a]
+        overheads.append(ov)
+        per_zq[meta[i][2]].append(ov)
+    arr = np.array(overheads)
+    return {
+        "n": int(len(arr)),
+        "mean_pct": float(100 * arr.mean()),
+        "p50_pct": float(100 * np.percentile(arr, 50)),
+        "p75_pct": float(100 * np.percentile(arr, 75)),
+        "p90_pct": float(100 * np.percentile(arr, 90)),
+        "argmin_acc": correct / len(arr),
+        "per_zq": {
+            tz: {
+                "n": len(v),
+                "mean": float(100 * np.mean(v)),
+                "p50": float(100 * np.percentile(v, 50)),
+                "p90": float(100 * np.percentile(v, 90)),
+            }
+            for tz, v in per_zq.items()
+        },
+    }
+
+
+def train_and_eval(X_tr, Y_tr, X_va, Y_va, meta_va, mask, n_configs, label):
+    Xtr = X_tr[:, mask]
+    Xva = X_va[:, mask]
+    sys.stderr.write(f"  [{label}] training {n_configs} per-config HistGBs (n_inputs={Xtr.shape[1]})...\n")
+    Y_pred = np.zeros_like(Y_va)
+    for cfg in range(n_configs):
+        m = ~np.isnan(Y_tr[:, cfg])
+        if m.sum() < 50:
+            Y_pred[:, cfg] = np.nanmean(Y_tr[:, cfg]) if m.any() else 0.0
+            continue
+        gbm = HistGradientBoostingRegressor(**HISTGB_KW)
+        gbm.fit(Xtr[m], Y_tr[m, cfg])
+        Y_pred[:, cfg] = gbm.predict(Xva)
+        if (cfg + 1) % 30 == 0:
+            sys.stderr.write(f"    {cfg + 1}/{n_configs} configs trained\n")
+    return evaluate(Y_pred, Y_va, meta_va)
+
+
+def main():
+    sys.stderr.write(f"Loading {PARETO}...\n")
+    pareto = load_pareto(PARETO)
+    feats, feat_cols = load_features(FEATURES)
+    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features\n")
+
+    X, Y, meta = build_dataset(pareto, feats, feat_cols)
+    n_configs = Y.shape[1]
+    n_total = X.shape[1]
+    rng = np.random.default_rng(SEED)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * HOLDOUT_FRAC))
+    val_set = set(images[:n_val])
+    train_idx = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    val_idx = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    sys.stderr.write(f"Train rows: {len(train_idx)}, val rows: {len(val_idx)}\n")
+    sys.stderr.write(f"HistGB: {HISTGB_KW}\n")
+
+    X_tr, Y_tr = X[train_idx], Y[train_idx]
+    X_va, Y_va = X[val_idx], Y[val_idx]
+    meta_va = [meta[i] for i in val_idx]
+    feat_idx = {n: i for i, n in enumerate(feat_cols)}
+
+    # Baseline (all 19 features).
+    sys.stderr.write("\n[1/2] Baseline (all 19 features, production HistGB)...\n")
+    baseline = train_and_eval(
+        X_tr, Y_tr, X_va, Y_va, meta_va, np.ones(n_total, dtype=bool), n_configs, "baseline"
+    )
+    sys.stderr.write(
+        f"  baseline: mean {baseline['mean_pct']:.2f}% p50 {baseline['p50_pct']:.2f}% "
+        f"p90 {baseline['p90_pct']:.2f}% argmin_acc {baseline['argmin_acc']:.1%}\n"
+    )
+
+    # Reduced (8 features).
+    keep_set = set(KEEP_FEATURES)
+    mask = np.zeros(n_total, dtype=bool)
+    kept = []
+    missing = []
+    for name in KEEP_FEATURES:
+        if name in feat_idx:
+            mask[feat_idx[name]] = True
+            kept.append(name)
+        else:
+            missing.append(name)
+    # Also keep size onehot + zq (always-on auxiliary inputs).
+    mask[len(feat_cols):] = True
+
+    if missing:
+        sys.stderr.write(f"  WARN missing: {missing}\n")
+
+    sys.stderr.write(f"\n[2/2] Reduced ({len(kept)} features, production HistGB)...\n")
+    sys.stderr.write(f"  features kept: {kept}\n")
+    reduced = train_and_eval(
+        X_tr, Y_tr, X_va, Y_va, meta_va, mask, n_configs, "reduced"
+    )
+    sys.stderr.write(
+        f"  reduced: mean {reduced['mean_pct']:.2f}% p50 {reduced['p50_pct']:.2f}% "
+        f"p90 {reduced['p90_pct']:.2f}% argmin_acc {reduced['argmin_acc']:.1%}\n"
+    )
+
+    delta = reduced["mean_pct"] - baseline["mean_pct"]
+    sys.stderr.write(f"\nΔ (reduced - baseline): {delta:+.2f}pp\n")
+
+    out = {
+        "baseline": baseline,
+        "reduced": reduced,
+        "kept_features": kept,
+        "histgb_params": HISTGB_KW,
+    }
+    OUT_JSON.write_text(json.dumps(out, indent=2))
+
+    lines = []
+
+    def w(s):
+        lines.append(s)
+        sys.stderr.write(s + "\n")
+
+    w("\n# Reduced schema validation — production HistGB")
+    w(f"Train rows: {len(X_tr)}, val rows: {len(X_va)}")
+    w(f"HistGB: {HISTGB_KW}")
+    w("")
+    w("## Comparison")
+    w(f"{'config':30s} {'mean':>10s} {'p50':>8s} {'p75':>8s} {'p90':>8s} {'argmin':>10s}")
+    w("-" * 75)
+    w(
+        f"{'baseline (19 features)':30s} "
+        f"{baseline['mean_pct']:>9.2f}% {baseline['p50_pct']:>7.2f}% "
+        f"{baseline['p75_pct']:>7.2f}% {baseline['p90_pct']:>7.2f}% "
+        f"{baseline['argmin_acc']:>9.1%}"
+    )
+    w(
+        f"{'reduced (8 features)':30s} "
+        f"{reduced['mean_pct']:>9.2f}% {reduced['p50_pct']:>7.2f}% "
+        f"{reduced['p75_pct']:>7.2f}% {reduced['p90_pct']:>7.2f}% "
+        f"{reduced['argmin_acc']:>9.1%}"
+    )
+    w(f"\nΔ mean: {delta:+.2f}pp")
+    w("")
+    w("## Per-zq comparison (mean overhead)")
+    w(f"{'zq':>4s} {'baseline':>10s} {'reduced':>10s} {'Δ':>8s}")
+    w("-" * 40)
+    for tz in sorted(set(baseline["per_zq"]) & set(reduced["per_zq"])):
+        b = baseline["per_zq"][tz]
+        r = reduced["per_zq"][tz]
+        d = r["mean"] - b["mean"]
+        w(f"{tz:>4d} {b['mean']:>9.2f}% {r['mean']:>9.2f}% {d:>+7.2f}pp")
+
+    OUT_LOG.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lifts the codec-agnostic picker training scripts from zenjpeg's \`scripts/\` folder to \`zenpicker/tools/\` so they're a first-class part of zenpicker rather than zenjpeg-specific tooling other codec crates would have to fork.

## Motivation

The training pipeline (per-config HistGB teachers → small distilled MLP → bake to v1 binary) is conceptually codec-agnostic — every codec crate (zenjpeg today, zenwebp / zenavif / zenjxl tomorrow) wants the same machinery. The actual codec-specific bits are tiny:
- TSV paths (codec's Pareto sweep + features outputs)
- \`feat_*\` column subset (codec-chosen feature schema)
- \`target_zq\` grid
- A regex/parser that decomposes the codec's config-name strings into categorical + scalar axes

This PR lifts the scripts to a single canonical home and parametrizes the codec-specific bits via a small "codec config module" the codec writes once.

## What ships

\`zenpicker/tools/\`:
- \`_picker_lib.py\` (renamed from \`_zq_picker_lib.py\`) — shared lib: dataset cache, parallel teachers, FAST/FULL HistGB presets, subsample helper, StepTimer
- \`train_hybrid.py\` (renamed from \`zq_hybrid_heads.py\`) — hybrid-heads training (recommended). Loads codec config via \`--codec-config <module>\`
- \`train_distill.py\`, \`train_distill_reduced.py\` (legacy v1.x picker shape)
- \`feature_ablation.py\`, \`feature_group_ablation.py\` — feature-importance pruning
- \`validate_schema.py\` — re-train production HistGB on a chosen subset, report metrics
- \`capacity_sweep.py\` — architecture × cross-term-recipe sweep
- \`tools/README.md\` — file map + end-to-end workflow + codec-config contract

\`zenpicker/examples/zenjpeg_picker_config.py\` — reference codec config the training pipeline imports. New codecs copy and edit.

zenpicker README + tools/README.md document the workflow:

\`\`\`bash
PYTHONPATH=zenanalyze/zenpicker/examples:zenanalyze/zenpicker/tools \\
    python3 zenanalyze/zenpicker/tools/train_hybrid.py \\
        --codec-config zenjpeg_picker_config
\`\`\`

## Verified end-to-end against zenjpeg's existing TSVs

- Same Pareto sweep TSV (\`benchmarks/zq_pareto_2026-04-29.tsv\` from zenjpeg)
- Same features TSV
- Same KEEP_FEATURES
- Same training output: teacher 2.13 % mean overhead / 55.5 % argmin acc, student 2.76 % / 52.0 % — bit-for-bit identical to the previous \`zenjpeg/scripts/zq_hybrid_heads.py\` run
- Wall-clock ~3 minutes (parallel teachers via joblib)
- Bake via \`tools/bake_picker.py\` produces same schema_hash \`0xe39b0b25870d23aa\`; round-trip-check still passes (max rel diff 4.0e-6)

## What stays in zenjpeg

- \`zenjpeg/examples/zq_pareto_calibrate.rs\` — codec encoder harness (knows EncoderConfig, ChromaSubsampling, jpegli q values). Codec-specific, stays.
- \`zenjpeg/scripts/zq_pareto_fit.py\`, \`zq_emit_rust.py\` — pre-picker artifacts, outside this PR's scope.

## What new codecs gain

zenwebp / zenavif / zenjxl write a 50-line codec config module (paths + feature schema + name parser), import the same training scripts, produce a bake. Single canonical pipeline; no per-codec drift. Bug fixes / speed-ups (like the parallel-teachers refactor) propagate to every codec automatically.

## Test plan

- [x] \`PYTHONPATH=… python3 train_hybrid.py --codec-config zenjpeg_picker_config\` runs end-to-end against zenjpeg's TSVs
- [x] Output JSON identical to the previous in-zenjpeg version
- [x] \`bake_picker.py\` consumes the JSON and produces the same bake (50084 bytes f16, schema_hash 0xe39b0b25870d23aa)
- [x] \`bake_roundtrip_check.py\` passes (max rel diff 4.0e-6)
- [ ] CI on the docs branch — should be a no-op pass for the Rust crate (Python additions don't affect the cargo build)