### PR TITLE
feat(zenpicker): argmin_masked_top_k<K> for cached second-best picks

### DIFF
--- a/zenpicker/src/lib.rs
+++ b/zenpicker/src/lib.rs
@@ -53,7 +53,7 @@ mod mask;
 mod model;
 
 pub use error::PickerError;
-pub use mask::{AllowedMask, argmin_masked};
+pub use mask::{AllowedMask, argmin_masked, argmin_masked_top_k};
 pub use model::{Activation, LayerView, Model, WeightDtype};
 
 /// Caller-supplied additive cost adjustments applied to the model's
@@ -196,6 +196,48 @@ impl<'a> Picker<'a> {
             });
         }
         Ok(mask::argmin_masked(&self.output[start..end], mask, adjust))
+    }
+
+    /// Pick the top-`K` argmin output indices over the masked set in
+    /// ascending score order (best first).
+    ///
+    /// Slots beyond the number of mask-allowed entries are `None`.
+    /// Codec rescue logic (two-shot pass framework) uses `K = 2` —
+    /// the second-best is the fallback when the first pick fails
+    /// post-encode verification.
+    pub fn argmin_masked_top_k<const K: usize>(
+        &mut self,
+        features: &[f32],
+        mask: &AllowedMask<'_>,
+        adjust: Option<CostAdjust<'_>>,
+    ) -> Result<[Option<usize>; K], PickerError> {
+        self.predict(features)?;
+        Ok(mask::argmin_masked_top_k::<K>(&self.output, mask, adjust))
+    }
+
+    /// `argmin_masked_top_k` over a sub-range, in line with
+    /// [`argmin_masked_in_range`]. Returns indices *within the
+    /// sub-range* (0..(range.1 - range.0)).
+    pub fn argmin_masked_top_k_in_range<const K: usize>(
+        &mut self,
+        features: &[f32],
+        range: (usize, usize),
+        mask: &AllowedMask<'_>,
+        adjust: Option<CostAdjust<'_>>,
+    ) -> Result<[Option<usize>; K], PickerError> {
+        self.predict(features)?;
+        let (start, end) = range;
+        if end > self.output.len() || start > end {
+            return Err(PickerError::FeatureLenMismatch {
+                expected: self.output.len(),
+                got: end,
+            });
+        }
+        Ok(mask::argmin_masked_top_k::<K>(
+            &self.output[start..end],
+            mask,
+            adjust,
+        ))
     }
 }
 

--- a/zenpicker/src/mask.rs
+++ b/zenpicker/src/mask.rs
@@ -90,6 +90,83 @@ pub fn argmin_masked(
     best_idx
 }
 
+/// Pick the `K` lowest-scoring indices over `predictions` that the
+/// mask permits, returned in ascending score order (best first).
+///
+/// Slots beyond the number of allowed entries are `None`. Score
+/// semantics match [`argmin_masked`]: log-space when `adjust` is
+/// `None`, raw-byte space otherwise.
+///
+/// `K` is generic to keep the call site allocation-free; in practice
+/// `K = 2` is what codec rescue logic wants (best + cached
+/// second-best for the two-shot rescue path).
+pub fn argmin_masked_top_k<const K: usize>(
+    predictions: &[f32],
+    mask: &AllowedMask<'_>,
+    adjust: Option<CostAdjust<'_>>,
+) -> [Option<usize>; K] {
+    debug_assert!(mask.len() >= predictions.len());
+
+    // Sorted ascending by score; `count` is how many slots are filled.
+    let mut top: [(f32, usize); K] = [(f32::INFINITY, usize::MAX); K];
+    let mut count: usize = 0;
+
+    let consider = |score: f32, idx: usize, top: &mut [(f32, usize); K], count: &mut usize| {
+        if *count < K {
+            // Insert in sorted position.
+            let mut i = *count;
+            while i > 0 && top[i - 1].0 > score {
+                top[i] = top[i - 1];
+                i -= 1;
+            }
+            top[i] = (score, idx);
+            *count += 1;
+        } else if K > 0 && score < top[K - 1].0 {
+            // Replace the worst-kept and bubble up.
+            let mut i = K - 1;
+            while i > 0 && top[i - 1].0 > score {
+                top[i] = top[i - 1];
+                i -= 1;
+            }
+            top[i] = (score, idx);
+        }
+    };
+
+    match adjust {
+        None => {
+            for (i, &score) in predictions.iter().enumerate() {
+                if !mask.is_allowed(i) {
+                    continue;
+                }
+                consider(score, i, &mut top, &mut count);
+            }
+        }
+        Some(CostAdjust {
+            additive_bytes,
+            per_output_offset,
+        }) => {
+            for (i, &score) in predictions.iter().enumerate() {
+                if !mask.is_allowed(i) {
+                    continue;
+                }
+                let mut bytes = clamped_exp(score) + additive_bytes;
+                if let Some(offsets) = per_output_offset
+                    && let Some(off) = offsets.get(i)
+                {
+                    bytes += *off;
+                }
+                consider(bytes, i, &mut top, &mut count);
+            }
+        }
+    }
+
+    let mut out: [Option<usize>; K] = [None; K];
+    for slot in 0..count {
+        out[slot] = Some(top[slot].1);
+    }
+    out
+}
+
 /// `exp` with input clamped to [-30, 30] to keep training-time
 /// out-of-range predictions from producing NaN/Inf at inference.
 fn clamped_exp(x: f32) -> f32 {

--- a/zenpicker/src/tests.rs
+++ b/zenpicker/src/tests.rs
@@ -290,6 +290,85 @@ fn argmin_picks_smallest_allowed() {
 }
 
 #[test]
+fn top_k_picks_smallest_allowed_in_order() {
+    let mut buf = alloc::vec::Vec::new();
+    // Predictions: [3.0, 1.0, 2.0, 0.5]
+    write_v1_model_f32(
+        &mut buf,
+        1,
+        &[(1, 4, 0, &[0.0, 0.0, 0.0, 0.0], &[3.0, 1.0, 2.0, 0.5])],
+        0,
+    );
+    let aligned = AlignedBuf::from_slice(&buf);
+    let model = Model::from_bytes(aligned.as_bytes()).unwrap();
+    let mut picker = Picker::new(model);
+
+    let mask_all = AllowedMask::new(&[true, true, true, true]);
+    let top2 = picker
+        .argmin_masked_top_k::<2>(&[0.0], &mask_all, None)
+        .unwrap();
+    assert_eq!(top2, [Some(3), Some(1)]);
+
+    let top3 = picker
+        .argmin_masked_top_k::<3>(&[0.0], &mask_all, None)
+        .unwrap();
+    assert_eq!(top3, [Some(3), Some(1), Some(2)]);
+
+    let top4 = picker
+        .argmin_masked_top_k::<4>(&[0.0], &mask_all, None)
+        .unwrap();
+    assert_eq!(top4, [Some(3), Some(1), Some(2), Some(0)]);
+
+    // K larger than number of allowed entries — surplus slots are None.
+    let top5 = picker
+        .argmin_masked_top_k::<5>(&[0.0], &mask_all, None)
+        .unwrap();
+    assert_eq!(top5, [Some(3), Some(1), Some(2), Some(0), None]);
+
+    // Mask out the best.
+    let mask_no3 = AllowedMask::new(&[true, true, true, false]);
+    let top2_masked = picker
+        .argmin_masked_top_k::<2>(&[0.0], &mask_no3, None)
+        .unwrap();
+    assert_eq!(top2_masked, [Some(1), Some(2)]);
+
+    // No allowed entries — all None.
+    let mask_none = AllowedMask::new(&[false, false, false, false]);
+    let top2_empty = picker
+        .argmin_masked_top_k::<2>(&[0.0], &mask_none, None)
+        .unwrap();
+    assert_eq!(top2_empty, [None, None]);
+}
+
+#[test]
+fn top_k_in_range_returns_subrange_indices() {
+    let mut buf = alloc::vec::Vec::new();
+    // 6 outputs split notionally [bytes_log[0..3], scalar1[0..3]].
+    write_v1_model_f32(
+        &mut buf,
+        1,
+        &[(
+            1,
+            6,
+            0,
+            &[0.0; 6],
+            &[3.0, 1.0, 2.0, /* scalar tail */ 999.0, 999.0, 999.0],
+        )],
+        0,
+    );
+    let aligned = AlignedBuf::from_slice(&buf);
+    let model = Model::from_bytes(aligned.as_bytes()).unwrap();
+    let mut picker = Picker::new(model);
+
+    let mask_all = AllowedMask::new(&[true, true, true]);
+    let top2 = picker
+        .argmin_masked_top_k_in_range::<2>(&[0.0], (0, 3), &mask_all, None)
+        .unwrap();
+    // Indices are within the sub-range, so 1 (= 1.0) and 2 (= 2.0).
+    assert_eq!(top2, [Some(1), Some(2)]);
+}
+
+#[test]
 fn rejects_bad_magic() {
     let mut buf = alloc::vec::Vec::new();
     write_v1_model_f32(&mut buf, 1, &[(1, 1, 0, &[1.0], &[0.0])], 0);


### PR DESCRIPTION
Additive helper that returns the K lowest-scoring mask-allowed indices in a single forward pass, in ascending score order.

Codec-side rescue logic in the two-shot pass framework (see [SAFETY_PLANE.md](https://github.com/imazen/zenanalyze/blob/main/zenpicker/SAFETY_PLANE.md)) needs to know the second-best pick at the moment it makes the first pick — so the cached top-2 lets a codec's rescue strategy try \`SecondBestPick\` without re-running inference.

## API surface (all additive, stays within 0.1.x freeze)

\`\`\`rust
// free fn
pub fn argmin_masked_top_k<const K: usize>(
    predictions: &[f32],
    mask: &AllowedMask<'_>,
    adjust: Option<CostAdjust<'_>>,
) -> [Option<usize>; K];

// methods on Picker
impl<'a> Picker<'a> {
    pub fn argmin_masked_top_k<const K: usize>(
        &mut self, features: &[f32], mask: &AllowedMask<'_>,
        adjust: Option<CostAdjust<'_>>,
    ) -> Result<[Option<usize>; K], PickerError>;

    pub fn argmin_masked_top_k_in_range<const K: usize>(
        &mut self, features: &[f32], range: (usize, usize),
        mask: &AllowedMask<'_>, adjust: Option<CostAdjust<'_>>,
    ) -> Result<[Option<usize>; K], PickerError>;
}
\`\`\`

Slots beyond the number of mask-allowed entries are \`None\`. Score semantics match \`argmin_masked\` (log-space when \`adjust\` is None, raw-byte space otherwise).

## Tests

- \`top_k_picks_smallest_allowed_in_order\` — K=2/3/4/5 on 4 outputs, with masking
- \`top_k_in_range_returns_subrange_indices\` — hybrid-heads layout (bytes_log subrange)

20 picker unit tests pass; clippy clean.