### PR TITLE
feat(zenpicker): reach_gate_mask — threshold as runtime parameter

### DIFF
--- a/zenpicker/README.md
+++ b/zenpicker/README.md
@@ -263,18 +263,26 @@ pub fn load_picker(profile: PickerProfile) -> Result<Picker<'static>, PickerErro
     Ok(Picker::new(model))
 }
 
-// At pick time, the manifest carries a per-target-zq reach-safety
-// table the codec ANDs into the constraint mask. For size_optimal
-// you can ignore the gate; for zensim_strict you should honor it.
+// At pick time, the manifest carries per-target-zq reach rates the
+// codec converts to an allow mask via `zenpicker::reach_gate_mask`,
+// then ANDs into its constraint mask. The threshold is a runtime
+// parameter — codec / caller picks it.
 //
-//   manifest.reach_safety.by_zq["85"].safe == [bool; n_cells]
+//   manifest.reach_safety.by_zq["85"].reach_rate == [f32; n_cells]
 //
 let mut mask = constraints.allowed_mask();   // from caller intent
 if profile == PickerProfile::ZensimStrict
-    && let Some(safe_cells) = manifest_safe_for(target_zq)
+    && let Some(rates) = manifest_reach_rate_for(target_zq)
 {
+    let mut gate = [false; N_CELLS];
+    let threshold = match caller.intent {
+        QualityIntent::Strict     => 0.99,  // SLA contract
+        QualityIntent::HighQ      => 0.95,  // relaxed
+        QualityIntent::MaxQuality => 0.0,   // disabled — relies on rescue
+    };
+    zenpicker::reach_gate_mask(&rates, threshold, &mut gate);
     for (i, allowed) in mask.iter_mut().enumerate() {
-        *allowed &= safe_cells[i];
+        *allowed &= gate[i];
     }
 }
 let cell_idx = picker.argmin_masked_in_range(&features, (0, N_CELLS), &AllowedMask::new(&mask), None)?;
@@ -282,7 +290,7 @@ let cell_idx = picker.argmin_masked_in_range(&features, (0, N_CELLS), &AllowedMa
 
 The size and runtime cost of carrying both bakes is small (~100 KB embedded total per codec, no inference-path changes — it's just two `Picker` instances). The codec exposes `PickerProfile` on its public encode API; imageflow / proxy operators flip per-request based on SLA requirements.
 
-The reach-safety table is shipped in **both** profiles' manifests (size_optimal carries it for transparency / debugging; the codec just doesn't apply it under that profile). The training script (`tools/train_hybrid.py --reach-threshold 0.99`) computes it as the empirical fraction of training rows in which each cell reached `target_zq`, then thresholds.
+The reach-safety table is shipped in **both** profiles' manifests (size_optimal carries it for transparency / debugging; the codec just doesn't apply the gate under that profile). The training script (`tools/train_hybrid.py --reach-threshold 0.99`) records both the raw `reach_rate[c]` per zq and a precomputed `safe[c]` boolean at the bake-time threshold. **Codec consumers should prefer the runtime helper** (`zenpicker::reach_gate_mask(reach_rates, threshold_at_request_time, out)`) so the threshold is a *parameter* — at very high target_zq (≥ 96), the strict 0.99 gate leaves 0–2 cells safe; "max-quality mode" callers pass `threshold = 0.0` and rely on the rescue path for tail safety. The bake-time `safe[]` is convenient when the codec wants the strict threshold without re-evaluating, nothing more.
 
 ### Caller-facing semantics
 

--- a/zenpicker/src/lib.rs
+++ b/zenpicker/src/lib.rs
@@ -54,7 +54,7 @@ mod model;
 pub mod rescue;
 
 pub use error::PickerError;
-pub use mask::{AllowedMask, argmin_masked, argmin_masked_top_k};
+pub use mask::{AllowedMask, argmin_masked, argmin_masked_top_k, reach_gate_mask};
 pub use model::{Activation, LayerView, Model, WeightDtype};
 pub use rescue::{RescueDecision, RescuePolicy, RescueStrategy, should_rescue};
 

--- a/zenpicker/src/mask.rs
+++ b/zenpicker/src/mask.rs
@@ -167,6 +167,40 @@ pub fn argmin_masked_top_k<const K: usize>(
     out
 }
 
+/// Fill `out` with the per-cell allow flags derived from a row of
+/// `reach_rate` values and a runtime threshold.
+///
+/// `out[i] = reach_rates[i] >= threshold` (with `NaN` mapped to
+/// `false` — non-finite rates mean the cell never participated in
+/// training and shouldn't be picked).
+///
+/// This is the runtime form of the bake-time `reach_safety` gate.
+/// The bake records raw per-cell reach rates per `target_zq`;
+/// codec consumers convert them to a mask with the threshold
+/// *they* pick at request time, which makes the gate a parameter
+/// rather than a baked constant. Typical settings:
+///
+/// - `0.99` — strict default. Pairs with the `zensim_strict`
+///   bake's contract ("p99 ≥ target − 1pp"). At very high
+///   `target_zq` (≥ 96) the strict gate may leave 0–2 cells
+///   allowed; codec falls through to
+///   `RescueStrategy::KnownGoodFallback`.
+/// - `0.95` — relaxed / "high quality" mode. Trades a small
+///   amount of tail safety for more cells available to argmin.
+/// - `0.0` — "max quality" / disabled. Allows any cell with a
+///   non-zero, non-NaN reach rate. Relies on the rescue path for
+///   tail safety. Recommended at the highest `target_zq` bands
+///   where the strict gate is empty by construction.
+///
+/// `out.len()` must equal `reach_rates.len()`. Caller AND's this
+/// against its constraint mask before [`argmin_masked`].
+pub fn reach_gate_mask(reach_rates: &[f32], threshold: f32, out: &mut [bool]) {
+    debug_assert_eq!(reach_rates.len(), out.len());
+    for (i, &r) in reach_rates.iter().enumerate() {
+        out[i] = r.is_finite() && r >= threshold;
+    }
+}
+
 /// `exp` with input clamped to [-30, 30] to keep training-time
 /// out-of-range predictions from producing NaN/Inf at inference.
 fn clamped_exp(x: f32) -> f32 {

--- a/zenpicker/src/tests.rs
+++ b/zenpicker/src/tests.rs
@@ -369,6 +369,31 @@ fn top_k_in_range_returns_subrange_indices() {
 }
 
 #[test]
+fn reach_gate_mask_thresholds_correctly() {
+    use crate::reach_gate_mask;
+
+    // Realistic per-cell reach rates at some target_zq band.
+    let rates = [1.0_f32, 0.99, 0.98, 0.96, 0.5, 0.0, f32::NAN];
+    let mut out = [false; 7];
+
+    // Strict default — only cells at/above 0.99 pass.
+    reach_gate_mask(&rates, 0.99, &mut out);
+    assert_eq!(out, [true, true, false, false, false, false, false]);
+
+    // Relaxed — 0.95 lets cells 0..3 through.
+    reach_gate_mask(&rates, 0.95, &mut out);
+    assert_eq!(out, [true, true, true, true, false, false, false]);
+
+    // Max-quality / disabled — any positive non-NaN cell passes.
+    reach_gate_mask(&rates, 0.0, &mut out);
+    assert_eq!(out, [true, true, true, true, true, true, false]);
+
+    // NaN never passes regardless of threshold.
+    reach_gate_mask(&[f32::NAN; 3], 0.0, &mut out[..3]);
+    assert_eq!(&out[..3], &[false, false, false]);
+}
+
+#[test]
 fn rejects_bad_magic() {
     let mut buf = alloc::vec::Vec::new();
     write_v1_model_f32(&mut buf, 1, &[(1, 1, 0, &[1.0], &[0.0])], 0);


### PR DESCRIPTION
Makes the zensim_strict reach gate a runtime parameter so codec consumers can expose a "max quality mode" without rebaking.

## API (additive, 0.1.x)

\`\`\`rust
pub fn reach_gate_mask(reach_rates: &[f32], threshold: f32, out: &mut [bool]);
\`\`\`

Codec consumers feed it the per-target_zq \`reach_rate\` row from the manifest and pick the threshold per-request:

| threshold | semantics |
|---|---|
| \`0.99\` | strict default — matches the zensim_strict bake's contract |
| \`0.95\` | relaxed / high-quality mode |
| \`0.00\` | max-quality mode, disabled — relies on the rescue path for tail safety. Recommended at \`target_zq >= 96\` where 0.99 leaves 0-2 cells safe by construction |

NaN reach rates map to \`false\` regardless of threshold (cell never participated in training).

## Why

The zensim_strict bake records \`safe[c] = reach_rate[c] >= 0.99\` at bake time. That hardcodes the threshold and excludes 'max quality' workloads from the picker entirely at high target_zq. Lifting the threshold to runtime keeps the bake stable but lets the caller scale safety vs availability per request — what the user asked for.

## Tests

\`reach_gate_mask_thresholds_correctly\` — strict / relaxed / disabled / NaN. 26 picker unit tests pass.