### PR TITLE
docs(zenpicker): refresh for shipped v0.1.x APIs

### DIFF
--- a/zenpicker/FOR_NEW_CODECS.md
+++ b/zenpicker/FOR_NEW_CODECS.md
@@ -289,6 +289,21 @@ The features vector packs zenanalyze outputs in the order declared in the bake m
 
 ---
 
+## Optional — safety profiles + rescue
+
+Once your codec ships a working `size_optimal` bake, you can add a second `zensim_strict` bake (worst-case-safe sizing) and wire the two-shot rescue path. Both use additive APIs zenpicker already exposes — no schema change.
+
+| Step | Where |
+|---|---|
+| Train the strict variant | `tools/train_hybrid.py --objective zensim_strict --codec-config <your_codec>_picker_config` |
+| Ship both bakes side-by-side via `include_bytes!` | `models/<your_codec>_picker_v2.0_{hybrid,zensim_strict}.bin` |
+| Honor the runtime reach gate | `zenpicker::reach_gate_mask(reach_rates_for_target_zq, threshold, &mut gate)` then AND with your constraint mask |
+| Run the two-shot rescue loop | `Picker::argmin_masked_top_k::<2>` for cached second-best + `zenpicker::rescue::should_rescue` for the threshold predicate |
+
+The full design + the codec orchestration sketch live in [SAFETY_PLANE.md](SAFETY_PLANE.md) and the README's [Safety profiles](README.md#safety-profiles-size_optimal-vs-zensim_strict) section. Defer all of this to v2 — your codec ships fine on `size_optimal` alone.
+
+---
+
 ## When to re-bake
 
 - Your codec's config grid changed (added/removed a knob).

--- a/zenpicker/README.md
+++ b/zenpicker/README.md
@@ -472,6 +472,8 @@ Memory: 30 KB (f16) or 60 KB (f32) embedded; one prediction call allocates nothi
 | ✅ v0.1 | **`zensim_strict` profile**: pinball-loss training (`train_hybrid.py --objective zensim_strict`) + per-`target_zq` reach-rate gate in the manifest. Pairs with `size_optimal` so codecs ship both bakes side by side |
 | ✅ v0.1 | **Top-K argmin** (`Picker::argmin_masked_top_k::<K>` / `argmin_masked_top_k_in_range`) for cached second-best picks — backbone of the codec-side rescue path |
 | ✅ v0.1 | **Rescue plumbing** (`zenpicker::rescue::{should_rescue, RescuePolicy, RescueStrategy, RescueDecision}`) — codec-agnostic decision logic; codec injects `verify` + `rescue_pick`. See [SAFETY_PLANE.md](SAFETY_PLANE.md) |
+| ✅ v0.1 | **Reach-gate as parameter** (`zenpicker::reach_gate_mask`) — codec / caller picks the threshold per request. Strict 0.99 = SLA mode, 0.95 = high-q, 0.0 = max-quality (relies on rescue) |
+| 🔜 v0.1 | **v2.1 retrain with new tier3 features** (`patch_fraction_fast`, `quant_survival_y/uv`) — needs re-running the zenjpeg pareto sweep harness against the new analyzer features TSV. Tracked in [imazen/zenanalyze#22](https://github.com/imazen/zenanalyze/issues/22) |
 | ⏳ v0.2 | `#[magetypes]`-dispatched matmul (AVX-512 / AVX2 / NEON / WASM SIMD128 / scalar). 8-wide f16 → f32 via F16C / FCVT |
 | ⏳ v0.3 | i8-quantized weights option (per-row scale) for the case where ~50 KB still isn't small enough |
 | ⏳ v0.3 | Generational re-encode picker (round-trip JPEG-source case): see [imazen/zenanalyze#13](https://github.com/imazen/zenanalyze/issues/13) |

--- a/zenpicker/SAFETY_PLANE.md
+++ b/zenpicker/SAFETY_PLANE.md
@@ -107,20 +107,42 @@ Imageflow scrapes these per request to detect attack waves: sustained `picker_re
 
 ## zenpicker API surface (additive only)
 
-zenpicker is frozen at 0.1.x. We need one additive helper for the second-best pick:
+All shipped in 0.1.x. No schema change, no `.bin` format change.
 
 ```rust
-pub fn argmin_masked_top_k<const K: usize>(
-    &mut self,
-    features: &[f32],
-    mask: &AllowedMask<'_>,
-    adjust: Option<CostAdjust<'_>>,
-) -> Result<[Option<usize>; K], PickerError>;
+// Cached second-best for SecondBestPick rescue.
+impl<'a> Picker<'a> {
+    pub fn argmin_masked_top_k<const K: usize>(
+        &mut self,
+        features: &[f32],
+        mask: &AllowedMask<'_>,
+        adjust: Option<CostAdjust<'_>>,
+    ) -> Result<[Option<usize>; K], PickerError>;
+
+    pub fn argmin_masked_top_k_in_range<const K: usize>(
+        &mut self,
+        features: &[f32],
+        range: (usize, usize),
+        mask: &AllowedMask<'_>,
+        adjust: Option<CostAdjust<'_>>,
+    ) -> Result<[Option<usize>; K], PickerError>;
+}
+
+// Codec-agnostic decision logic.
+pub mod rescue {
+    pub struct RescuePolicy { pub rescue_threshold_pp: f32, pub strategy: RescueStrategy }
+    pub enum RescueStrategy { ConservativeBump, SecondBestPick, KnownGoodFallback }
+    pub enum RescueDecision { Ship, Rescue }
+    pub fn should_rescue(achieved_zq: f32, target_zq: f32, &RescuePolicy) -> RescueDecision;
+}
+
+// Reach gate as a runtime parameter — codec / caller picks threshold.
+pub fn reach_gate_mask(reach_rates: &[f32], threshold: f32, out: &mut [bool]);
 ```
 
-`K=2` covers our use case. No new types, no schema change, model `.bin` unchanged.
+`K=2` covers the second-best-pick use case. The reach gate is a *parameter*, not a baked constant — the bake records raw `reach_rate[c]` per `target_zq` in the manifest's `reach_safety` table, and codec consumers convert with `reach_gate_mask` at request time using whatever threshold matches the caller's `QualityIntent` (0.99 strict / 0.95 high-q / 0.0 max-quality).
 
-The bake-time tripwire ("predicted-bytes confidence quantile per cell" used by the cheap pre-filter) is bake-side metadata: pack a `[f32; n_cells]` of the bottom-decile threshold into the `.bin`'s post-header extension area (the format already advertises `header_size` for forward compat). Picker exposes it via a passthrough getter.
+The bake-time tripwire ("predicted-bytes confidence quantile per cell" used by the cheap pre-filter) is bake-side metadata: pack a `[f32; n_cells]` of the bottom-decile threshold into the `.bin`'s post-header extension area (the format already advertises `header_size` for forward compat). Picker exposes it via a passthrough getter — *not yet implemented*; `reach_safety` covers the SLA-mode gate today.
 
 ## Adversarial-corpus regression test
 
@@ -143,5 +165,8 @@ The bake-time tripwire ("predicted-bytes confidence quantile per cell" used by t
 - `zenjpeg/zenjpeg/src/encode/zq.rs` — the iteration loop; gains `RescuePolicy` field
 - `zenjpeg/zenjpeg/src/encode/byte_encoders.rs` — `EncodeMetrics` extension
 - `zenjpeg/zenjpeg/src/encode/encoder_types.rs` — `RescueStrategy` / `PickerWarning` enums
-- `zenanalyze/zenpicker/src/lib.rs` — `argmin_masked_top_k`
-- `zenanalyze/zenpicker/src/mask.rs` — supporting helpers
+- `zenanalyze/zenpicker/src/lib.rs` — `argmin_masked_top_k`, `reach_gate_mask` re-exports
+- `zenanalyze/zenpicker/src/mask.rs` — `argmin_masked_top_k`, `reach_gate_mask` impl
+- `zenanalyze/zenpicker/src/rescue.rs` — `should_rescue`, `RescuePolicy`, `RescueStrategy`, `RescueDecision`
+- `zenanalyze/zenpicker/tools/train_hybrid.py` — `--objective {size_optimal,zensim_strict}`, `--reach-threshold`
+- `zenanalyze/tools/bake_picker.py` — `safety_profile` / `training_objective` / `reach_safety` manifest passthrough


### PR DESCRIPTION
Pure doc refresh — no code changes.

- README v0.1 status table: adds \`reach_gate_mask\` (just landed in #29) and the v2.1-retrain row pointing at zenanalyze#22
- SAFETY_PLANE: replace the speculative 'we need one helper' section with the actual shipped API (top_k, rescue module, reach_gate_mask). Update 'Critical files' to point at the real impl paths
- FOR_NEW_CODECS: new optional 'Step 8 — safety profiles + rescue' so codec authors discover the two-bake / rescue path. Defers to README + SAFETY_PLANE for detail

Auto-merge with "even one test plat pass" rule per project workflow.