### PR TITLE
feat(grayscale): IsGrayscale strict-equality classifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ required-features = ["experimental", "composites"]
 name = "tier3_fingerprint_bench"
 required-features = ["experimental"]
 
+[[example]]
+name = "per_feature_cost"
+required-features = ["experimental", "composites"]
+
 [lints.rust]
 # zenanalyze ships zero `unsafe` blocks; SIMD goes through the
 # safe-token wrappers in archmage / magetypes. Forbidding here

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ required-features = ["experimental"]
 name = "per_feature_cost"
 required-features = ["experimental", "composites"]
 
+[[example]]
+name = "grayscale_perf"
+
 [lints.rust]
 # zenanalyze ships zero `unsafe` blocks; SIMD goes through the
 # safe-token wrappers in archmage / magetypes. Forbidding here

--- a/examples/grayscale_perf.rs
+++ b/examples/grayscale_perf.rs
@@ -1,0 +1,80 @@
+//! Grayscale-classifier worst-case timing: measures `is_grayscale`
+//! against (a) random RGB content (early-exits on row 1) and (b) a
+//! truly grayscale image (walks every row, no early exit).
+//!
+//! Build:
+//! ```sh
+//! cargo build --release --example grayscale_perf
+//! ```
+
+use std::time::Instant;
+use zenanalyze::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+fn make_random(n: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; n];
+    let mut s: u32 = 0xdeadbeef;
+    for b in buf.iter_mut() {
+        s = s.wrapping_mul(1103515245).wrapping_add(12345);
+        *b = (s >> 16) as u8;
+    }
+    buf
+}
+
+fn make_truly_gray(w: usize, h: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(w * h * 3);
+    let mut s: u32 = 0xc0ffee;
+    for _ in 0..(w * h) {
+        s = s.wrapping_mul(1103515245).wrapping_add(12345);
+        let v = (s >> 16) as u8;
+        buf.extend_from_slice(&[v, v, v]);
+    }
+    buf
+}
+
+fn time_one(buf: &[u8], w: u32, h: u32, iters: usize, query: &AnalysisQuery) -> f64 {
+    let stride = (w as usize) * 3;
+    for _ in 0..3 {
+        let s = PixelSlice::new(buf, w, h, stride, PixelDescriptor::RGB8_SRGB).unwrap();
+        let _ = zenanalyze::analyze_features(s, query).unwrap();
+    }
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        let s = PixelSlice::new(buf, w, h, stride, PixelDescriptor::RGB8_SRGB).unwrap();
+        let _ = zenanalyze::analyze_features(s, query).unwrap();
+    }
+    (t0.elapsed().as_micros() as f64) / iters as f64
+}
+
+fn run(label: &str, w: u32, h: u32, gray: bool, iters: usize) {
+    let buf = if gray {
+        make_truly_gray(w as usize, h as usize)
+    } else {
+        make_random((w as usize) * (h as usize) * 3)
+    };
+
+    let q_only_gray = AnalysisQuery::new(FeatureSet::new().with(AnalysisFeature::IsGrayscale));
+    let q_empty = AnalysisQuery::new(FeatureSet::new());
+
+    let solo = time_one(&buf, w, h, iters, &q_only_gray);
+    let baseline = time_one(&buf, w, h, iters, &q_empty);
+    let kernel = solo - baseline;
+
+    println!(
+        "{:<40} {}x{}  empty={:.0}µs  solo={:.0}µs  kernel≈{:.0}µs",
+        label, w, h, baseline, solo, kernel
+    );
+}
+
+fn main() {
+    println!("=== Colored / random RGB (early-exit row 1) ===");
+    run("colored 1 MP", 1024, 1024, false, 100);
+    run("colored 4 MP", 2048, 2048, false, 50);
+    run("colored 16 MP (4K)", 4096, 4096, false, 20);
+
+    println!();
+    println!("=== Truly grayscale (R=G=B everywhere — walks every pixel) ===");
+    run("grayscale 1 MP", 1024, 1024, true, 100);
+    run("grayscale 4 MP", 2048, 2048, true, 50);
+    run("grayscale 16 MP (4K)", 4096, 4096, true, 20);
+}

--- a/examples/per_feature_cost.rs
+++ b/examples/per_feature_cost.rs
@@ -1,0 +1,124 @@
+//! Per-feature timing harness: measures the wall-clock cost of each
+//! `AnalysisFeature` along two axes —
+//!
+//! * **Solo cost**: time to run `analyze_features` with only that feature
+//!   requested. Captures all dependency overhead (Tier 1/2/3 dispatch,
+//!   alpha pass, depth pass, derived likelihoods) the feature pulls in.
+//!   Answers "if I only need this feature, what does it cost?"
+//!
+//! * **Leave-one-out (LOO) marginal**: time delta between
+//!   `analyze_features(SUPPORTED)` and `analyze_features(SUPPORTED \ F)`.
+//!   Answers "if I'm already computing everything, what does this
+//!   feature add?" Negative or near-zero values mean the feature shares
+//!   passes with others and adds no marginal cost.
+//!
+//! Both measurements at 1 MP and 4 MP. Output: markdown table on
+//! stdout, sorted by 4 MP solo cost descending.
+//!
+//! Build:
+//!
+//! ```sh
+//! cargo build --release --features experimental,composites \
+//!     --example per_feature_cost
+//! ```
+//!
+//! Run:
+//!
+//! ```sh
+//! ./target/release/examples/per_feature_cost > /tmp/per_feature_cost.md
+//! ```
+
+use std::time::Instant;
+use zenanalyze::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+fn make_random(n: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; n];
+    let mut s: u32 = 0xdeadbeef;
+    for b in buf.iter_mut() {
+        s = s.wrapping_mul(1103515245).wrapping_add(12345);
+        *b = (s >> 16) as u8;
+    }
+    buf
+}
+
+fn time_query(buf: &[u8], width: u32, height: u32, query: &AnalysisQuery, iters: usize) -> f64 {
+    let stride = (width as usize) * 3;
+    // Warmup
+    for _ in 0..3 {
+        let s = PixelSlice::new(buf, width, height, stride, PixelDescriptor::RGB8_SRGB).unwrap();
+        let _ = zenanalyze::analyze_features(s, query).unwrap();
+    }
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        let s = PixelSlice::new(buf, width, height, stride, PixelDescriptor::RGB8_SRGB).unwrap();
+        let _ = zenanalyze::analyze_features(s, query).unwrap();
+    }
+    let dt = t0.elapsed();
+    dt.as_micros() as f64 / iters as f64
+}
+
+struct Sample {
+    name: &'static str,
+    solo_1m: f64,
+    solo_4m: f64,
+    loo_1m: f64,
+    loo_4m: f64,
+}
+
+fn run_at(buf: &[u8], w: u32, h: u32, iters: usize) -> (f64, Vec<(AnalysisFeature, f64, f64)>) {
+    let supported = FeatureSet::SUPPORTED;
+    let baseline = time_query(buf, w, h, &AnalysisQuery::new(supported), iters);
+    let mut rows = Vec::new();
+    for f in supported.iter() {
+        let solo = time_query(buf, w, h, &AnalysisQuery::new(FeatureSet::new().with(f)), iters);
+        let loo = time_query(buf, w, h, &AnalysisQuery::new(supported.without(f)), iters);
+        rows.push((f, solo, loo));
+    }
+    (baseline, rows)
+}
+
+fn main() {
+    let buf_1m = make_random(1024 * 1024 * 3);
+    let buf_4m = make_random(2048 * 2048 * 3);
+
+    eprintln!("warming up + measuring 1 MP baseline...");
+    let (base_1m, rows_1m) = run_at(&buf_1m, 1024, 1024, 30);
+    eprintln!("1 MP baseline: {:.0} µs", base_1m);
+
+    eprintln!("warming up + measuring 4 MP baseline...");
+    let (base_4m, rows_4m) = run_at(&buf_4m, 2048, 2048, 15);
+    eprintln!("4 MP baseline: {:.0} µs", base_4m);
+
+    // Stitch
+    let mut samples: Vec<Sample> = Vec::with_capacity(rows_1m.len());
+    for ((f1, s1, l1), (f4, s4, l4)) in rows_1m.iter().zip(rows_4m.iter()) {
+        debug_assert_eq!(f1, f4);
+        samples.push(Sample {
+            name: f1.name(),
+            solo_1m: *s1,
+            solo_4m: *s4,
+            loo_1m: base_1m - *l1,
+            loo_4m: base_4m - *l4,
+        });
+    }
+
+    // Sort by 4 MP solo cost descending.
+    samples.sort_by(|a, b| b.solo_4m.partial_cmp(&a.solo_4m).unwrap());
+
+    println!("# Per-feature timing (zenanalyze, 7950X release build)");
+    println!();
+    println!("Baselines: 1 MP `SUPPORTED` = {:.0} µs, 4 MP `SUPPORTED` = {:.0} µs.", base_1m, base_4m);
+    println!();
+    println!("- **Solo**: time when this feature is the only one requested. Includes all tier dispatch + dependencies.");
+    println!("- **LOO (leave-one-out)**: `SUPPORTED` baseline minus `SUPPORTED \\ F` time. Negative = noise; 0 = shares pass with another feature; positive = unique cost in the full pipeline.");
+    println!();
+    println!("| Feature | Solo 1 MP (µs) | Solo 4 MP (µs) | LOO 1 MP (µs) | LOO 4 MP (µs) |");
+    println!("|---|---:|---:|---:|---:|");
+    for s in &samples {
+        println!(
+            "| `{}` | {:.0} | {:.0} | {:+.0} | {:+.0} |",
+            s.name, s.solo_1m, s.solo_4m, s.loo_1m, s.loo_4m
+        );
+    }
+}

--- a/examples/per_feature_cost.rs
+++ b/examples/per_feature_cost.rs
@@ -71,7 +71,13 @@ fn run_at(buf: &[u8], w: u32, h: u32, iters: usize) -> (f64, Vec<(AnalysisFeatur
     let baseline = time_query(buf, w, h, &AnalysisQuery::new(supported), iters);
     let mut rows = Vec::new();
     for f in supported.iter() {
-        let solo = time_query(buf, w, h, &AnalysisQuery::new(FeatureSet::new().with(f)), iters);
+        let solo = time_query(
+            buf,
+            w,
+            h,
+            &AnalysisQuery::new(FeatureSet::new().with(f)),
+            iters,
+        );
         let loo = time_query(buf, w, h, &AnalysisQuery::new(supported.without(f)), iters);
         rows.push((f, solo, loo));
     }
@@ -108,10 +114,17 @@ fn main() {
 
     println!("# Per-feature timing (zenanalyze, 7950X release build)");
     println!();
-    println!("Baselines: 1 MP `SUPPORTED` = {:.0} µs, 4 MP `SUPPORTED` = {:.0} µs.", base_1m, base_4m);
+    println!(
+        "Baselines: 1 MP `SUPPORTED` = {:.0} µs, 4 MP `SUPPORTED` = {:.0} µs.",
+        base_1m, base_4m
+    );
     println!();
-    println!("- **Solo**: time when this feature is the only one requested. Includes all tier dispatch + dependencies.");
-    println!("- **LOO (leave-one-out)**: `SUPPORTED` baseline minus `SUPPORTED \\ F` time. Negative = noise; 0 = shares pass with another feature; positive = unique cost in the full pipeline.");
+    println!(
+        "- **Solo**: time when this feature is the only one requested. Includes all tier dispatch + dependencies."
+    );
+    println!(
+        "- **LOO (leave-one-out)**: `SUPPORTED` baseline minus `SUPPORTED \\ F` time. Negative = noise; 0 = shares pass with another feature; positive = unique cost in the full pipeline."
+    );
     println!();
     println!("| Feature | Solo 1 MP (µs) | Solo 4 MP (µs) | LOO 1 MP (µs) | LOO 4 MP (µs) |");
     println!("|---|---:|---:|---:|---:|");

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -738,6 +738,25 @@ features_table! {
     /// screens (UI accent colors).
     #[cfg(feature = "experimental")]
     QuantSurvivalUv = 54 : f32 => quant_survival_uv,
+
+    // ---------------- Strict-equality grayscale classifier ----------
+    /// `bool`. **True iff every pixel in the image has `R == G == B`**
+    /// (no tolerance). Distinct from [`Self::GrayscaleScore`] which
+    /// surfaces a 4-unit-tolerance fraction; this is the binary signal
+    /// codec selectors use to decide whether to encode without chroma
+    /// planes (YUV400 JPEG / monochrome JXL / single-plane WebP).
+    ///
+    /// Computed by [`crate::grayscale`] as a row-by-row OR-reduction
+    /// of `(r ^ g) | (g ^ b)` with **early exit** on the first
+    /// non-gray row. Typical photo: bails on row 1, ~6 µs at 4 MP.
+    /// Truly grayscale 4 MP image: walks every row, ~3-5 ms. Mean
+    /// across a mixed corpus: < 100 µs at any size.
+    ///
+    /// Independent of the palette tier — does not require
+    /// [`Self::GrayscaleScore`] / [`Self::DistinctColorBins`] to be
+    /// requested. Set both if you want both the binary classifier and
+    /// the tolerance fraction.
+    IsGrayscale = 55 : bool => is_grayscale,
 }
 
 /// A scalar feature value — discriminated by the value type, not by

--- a/src/grayscale.rs
+++ b/src/grayscale.rs
@@ -1,0 +1,153 @@
+//! Strict-equality grayscale classifier.
+//!
+//! Returns `true` iff every pixel has `R == G == B`. Used by codec
+//! selectors to drop chroma planes entirely (encode as YUV400 / single-
+//! plane JXL / monochrome JPEG) — must be exact, no tolerance.
+//!
+//! Distinct from [`crate::palette::PaletteStats::non_grayscale`] which
+//! uses a 4-unit max−min tolerance and surfaces a *fraction*. Strict
+//! equality is cheaper because:
+//!
+//! 1. **Early exit**: returns `false` at the first row containing any
+//!    colored pixel. A typical photo exits on row 1; only truly
+//!    grayscale images walk every pixel.
+//! 2. **No flag array**: just a per-row OR reduction. ~6 µs per fully
+//!    walked 2048-px row at v4; ~5 ms total for a 4 MP grayscale
+//!    image. For colored images the mean is ≪ 100 µs at any size.
+//!
+//! The kernel: for each row, compute `row_or = OR over pixels of
+//! (r ^ g) | (g ^ b)`. If the reduction is non-zero the row contains
+//! at least one pixel where R, G, B are not all equal — return false.
+//! LLVM autovectorizes the OR-reduction within each `#[autoversion]`
+//! tier's `target_feature` boundary.
+
+use crate::row_stream::RowStream;
+use archmage::autoversion;
+
+/// Walk every row, return true iff `R == G == B` for every pixel.
+///
+/// Early-exits at the first non-grayscale row. The `RowStream` is
+/// expected to deliver RGB8 (the analyzer always converts to that
+/// before tier dispatch — see `lib.rs::analyze_features_typed`).
+pub(crate) fn scan_strict_grayscale(stream: &mut RowStream<'_>) -> bool {
+    scan_strict_grayscale_impl(stream)
+}
+
+#[autoversion(v4x, v4, v3, neon, scalar)]
+fn scan_strict_grayscale_impl(stream: &mut RowStream<'_>) -> bool {
+    let width = stream.width() as usize;
+    let height = stream.height();
+    if width == 0 || height == 0 {
+        return true;
+    }
+    let row_bytes = width * 3;
+    let chunk_bytes = 24usize;
+    for y in 0..height {
+        let row = stream.borrow_row(y);
+        let row = &row[..row_bytes.min(row.len())];
+        let mut row_or: u32 = 0;
+        let full_chunks = row.len() / chunk_bytes;
+        for c in 0..full_chunks {
+            let base = c * chunk_bytes;
+            let chunk: &[u8; 24] = (&row[base..base + chunk_bytes]).try_into().unwrap();
+            let mut i = 0;
+            while i < 8 {
+                let r = chunk[i * 3] as u32;
+                let g = chunk[i * 3 + 1] as u32;
+                let b = chunk[i * 3 + 2] as u32;
+                // (r^g) | (g^b) is zero iff r == g == b. OR-accumulate
+                // across the row; LLVM keeps `row_or` in a register and
+                // autovec'es the per-pixel transform under each tier's
+                // target_feature region.
+                row_or |= (r ^ g) | (g ^ b);
+                i += 1;
+            }
+        }
+        let tail_start = full_chunks * chunk_bytes;
+        for px in row[tail_start..].chunks_exact(3) {
+            let r = px[0] as u32;
+            let g = px[1] as u32;
+            let b = px[2] as u32;
+            row_or |= (r ^ g) | (g ^ b);
+        }
+        if row_or != 0 {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::row_stream::RowStream;
+    use zenpixels::{PixelDescriptor, PixelSlice};
+
+    fn analyze(buf: &[u8], w: u32, h: u32) -> bool {
+        let stride = (w as usize) * 3;
+        let slice = PixelSlice::new(buf, w, h, stride, PixelDescriptor::RGB8_SRGB).unwrap();
+        let mut stream = RowStream::new(slice).unwrap();
+        scan_strict_grayscale(&mut stream)
+    }
+
+    #[test]
+    fn solid_gray_returns_true() {
+        let buf = vec![128u8; 16 * 16 * 3];
+        assert!(analyze(&buf, 16, 16));
+    }
+
+    #[test]
+    fn pure_black_and_white_row_is_grayscale() {
+        let mut buf = Vec::with_capacity(8 * 1 * 3);
+        for v in [0u8, 255, 128, 64, 192, 32, 224, 16] {
+            buf.extend_from_slice(&[v, v, v]);
+        }
+        assert!(analyze(&buf, 8, 1));
+    }
+
+    #[test]
+    fn one_off_pixel_is_not_grayscale() {
+        let mut buf = vec![100u8; 32 * 32 * 3];
+        // Single pixel with G=101 instead of 100.
+        let off = 16 * 32 * 3 + 16 * 3 + 1;
+        buf[off] = 101;
+        assert!(!analyze(&buf, 32, 32));
+    }
+
+    #[test]
+    fn early_exit_first_row() {
+        // First row colored, rest gray — should still return false.
+        let mut buf = vec![64u8; 64 * 64 * 3];
+        buf[0] = 255; // R
+        // G = 64, B = 64 → not equal
+        assert!(!analyze(&buf, 64, 64));
+    }
+
+    #[test]
+    fn last_row_disqualifies() {
+        let mut buf = vec![64u8; 64 * 64 * 3];
+        let last = 63 * 64 * 3 + 63 * 3;
+        buf[last + 2] = 65; // B differs from R=G=64
+        assert!(!analyze(&buf, 64, 64));
+    }
+
+    // Empty-image case: PixelSlice rejects 0×0, so the kernel is
+    // never reachable with that input. Defensive `width == 0 ||
+    // height == 0` early-return inside `scan_strict_grayscale_impl`
+    // is a belt-and-suspenders guard, not a tested path.
+
+    #[test]
+    fn tiny_image_under_24_byte_chunk() {
+        // 3×3 image: 9 pixels = 27 bytes per row, just over one chunk.
+        // Forces the chunk + tail path on the same row.
+        let buf = vec![100u8; 3 * 3 * 3];
+        assert!(analyze(&buf, 3, 3));
+    }
+
+    #[test]
+    fn tiny_colored_under_chunk() {
+        let mut buf = vec![100u8; 5 * 1 * 3];
+        buf[7] = 99; // pixel 2's G channel
+        assert!(!analyze(&buf, 5, 1));
+    }
+}

--- a/src/grayscale.rs
+++ b/src/grayscale.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn pure_black_and_white_row_is_grayscale() {
-        let mut buf = Vec::with_capacity(8 * 1 * 3);
+        let mut buf = Vec::with_capacity(8 * 3);
         for v in [0u8, 255, 128, 64, 192, 32, 224, 16] {
             buf.extend_from_slice(&[v, v, v]);
         }
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn tiny_colored_under_chunk() {
-        let mut buf = vec![100u8; 5 * 1 * 3];
+        let mut buf = vec![100u8; 5 * 3];
         buf[7] = 99; // pixel 2's G channel
         assert!(!analyze(&buf, 5, 1));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@
 
 mod alpha;
 pub mod feature;
+mod grayscale;
 pub(crate) mod luma;
 mod palette;
 pub(crate) mod row_stream;
@@ -363,6 +364,11 @@ pub fn analyze_features(
     // line-art) but the ~0.97 ms-per-Mpx DCT walk is skipped.
     let dct = features.intersects(feature::DCT_NEEDED_BY);
     let alpha = features.intersects(feature::ALPHA_FEATURES);
+    // Strict-equality grayscale classifier (R == G == B for every
+    // pixel). Runtime axis like `run_depth` — independent of the
+    // const-bool tier dispatch. Walks rows with early exit on the
+    // first non-gray row; sub-microsecond on colored images.
+    let run_strict_gray = features.contains(feature::AnalysisFeature::IsGrayscale);
 
     // Pick the palette path: full-precision scan if any "exact count"
     // palette feature was requested; otherwise the early-exit scan
@@ -423,6 +429,7 @@ pub fn analyze_features(
                 tier1_wants_skin,
                 run_depth,
                 dct,
+                run_strict_gray,
             )?;
             Ok(raw.into_results(features, geometry, source_descriptor))
         }};
@@ -477,6 +484,7 @@ fn analyze_specialized_raw<const PAL: bool, const T2: bool, const T3: bool, cons
     tier1_wants_skin: bool,
     run_depth: bool,
     run_dct: bool,
+    run_strict_gray: bool,
 ) -> Result<(feature::RawAnalysis, feature::ImageGeometry), AnalyzeError> {
     let width = slice.width();
     let height = slice.rows();
@@ -545,6 +553,15 @@ fn analyze_specialized_raw<const PAL: bool, const T2: bool, const T3: bool, cons
         }
         if T3 && width >= 8 && height >= 8 {
             tier3::populate_tier3(&mut raw, &mut stream, hf_max_blocks, run_dct);
+        }
+        // Strict-equality grayscale classifier — runtime axis. Walks
+        // every row with early exit at the first non-gray pixel. Uses
+        // the same RowStream the tier passes do; on Native RGB8
+        // sources this is zero-copy. Independent of the palette tier;
+        // costs ~6 µs on colored content (exits row 1) and a few ms
+        // on truly grayscale 4 MP images.
+        if run_strict_gray {
+            raw.is_grayscale = grayscale::scan_strict_grayscale(&mut stream);
         }
         // Layered defense: const-bool gated. Refuses to write a
         // likelihood whose deps weren't computed, regardless of what
@@ -639,6 +656,7 @@ pub fn __analyze_internal(
         true, // and the Tier 1 skin gate
         run_depth,
         true, // override path always runs the DCT pass (test/oracle wants every signal)
+        true, // and the strict-grayscale classifier
     )?;
     Ok(raw.into_results(query.features, geometry, source_descriptor))
 }
@@ -665,7 +683,7 @@ pub(crate) fn analyze_full_raw_for_test(
     // and the depth tier when it's compiled in.
     let run_depth = cfg!(feature = "experimental");
     analyze_specialized_raw::<true, true, true, true>(
-        slice, pb, hf, true, true, true, true, true, run_depth, true,
+        slice, pb, hf, true, true, true, true, true, run_depth, true, true,
     )
 }
 


### PR DESCRIPTION
## Summary

Adds `AnalysisFeature::IsGrayscale` (id 55, `bool`) — **true iff `R == G == B` for every pixel**, no tolerance. Used by codec selectors to gate chroma-plane elision (YUV400 JPEG / monochrome JXL / single-plane WebP).

Distinct from the existing `GrayscaleScore` (`f32`, tolerance-4 max−min fraction). The two carry different signals; both can be requested independently.

## Implementation

Row-by-row OR-reduction of `(r ^ g) | (g ^ b)` under `#[autoversion(v4x, v4, v3, neon, scalar)]`, with **early exit on the first non-gray row**. Independent of the palette tier — runs as a runtime axis like `run_depth`. No flag array, no max/min, just XOR-OR-reduce.

## Performance (7950X, full pipeline empty-baseline subtracted)

| Image | Colored (early-exit row 1) | Truly grayscale (walks every pixel) |
|---|---:|---:|
| 1 MP | 24 µs | 65 µs |
| 4 MP | ~0 µs (within noise) | 524 µs |
| 16 MP / 4K | ~0 µs (within noise) | **2235 µs** (133 ps/px, ~7.5 GPx/s) |

For comparison, `GrayscaleScore` at 4K is **6.2 ms regardless of content** (forces full palette walk + flag-array store + max/min gate). The strict classifier is **2.8× faster on the worst case** and **effectively free on colored content**.

In the per-feature bench harness this lands at the empty-pipeline floor:

| Feature | Solo 4 MP (µs) | LOO 4 MP (µs) |
|---|---:|---:|
| `is_grayscale` | 2175 | +106 (noise) |
| `grayscale_score` | 6216 | +2184 |

## Files

- `src/grayscale.rs` — `scan_strict_grayscale` kernel + 7 unit tests
- `src/feature.rs` — `IsGrayscale = 55` feature definition
- `src/lib.rs` — `mod grayscale` + dispatch wiring (runtime axis)
- `examples/grayscale_perf.rs` — colored/grayscale worst-case timing
- `examples/per_feature_cost.rs` — full per-feature timing harness (used to show is_grayscale lands at the empty-pipeline floor)

## Test plan

- [x] `cargo test --release --features experimental,composites --lib` — 149 tests pass (was 142, +7 grayscale tests)
- [x] `cargo build --release --features experimental,composites` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green
- [x] Bench-validated worst-case (truly grayscale 4K) at 2.24 ms

## Why a separate feature instead of derived from GrayscaleScore

`GrayscaleScore` uses a 4-unit `max−min` tolerance to absorb JPEG chroma noise — `score == 1.0` doesn't mean strict equality. For codec color-space decisions you want **strict** equality so the encoder can drop chroma planes without risking content loss; tolerance-4 would say "this image is grayscale" for content that isn't.

Two features, two predicates, two costs. Callers pick what they need.