### PR TITLE
feat(zenpicker): four more pathology seatbelts

### DIFF
--- a/tools/bake_picker.py
+++ b/tools/bake_picker.py
@@ -295,6 +295,30 @@ def bake(
         # bake-time --allow-unsafe override (defense in depth).
         if "safety_report" in model:
             manifest["safety_report"] = model["safety_report"]
+            # Lift feature_bounds to the top-level of the manifest so
+            # codecs can compile a `FEATURE_BOUNDS: &[(f32, f32)]` const
+            # from a stable path. The full per-percentile dict stays
+            # inside safety_report.diagnostics; the lifted form is a
+            # compact list aligned to feat_cols, picking (p01, p99) by
+            # default. Codecs that want different bounds can read the
+            # full dict instead.
+            fb = (
+                model["safety_report"]
+                .get("diagnostics", {})
+                .get("feature_bounds")
+            )
+            if fb:
+                lifted = []
+                for col in feat_cols:
+                    s = fb.get(col)
+                    if s and s.get("p01") is not None and s.get("p99") is not None:
+                        lifted.append({"feat": col, "low": s["p01"], "high": s["p99"]})
+                    else:
+                        # If we have no usable percentiles, fall back
+                        # to (-inf, +inf) so the runtime gate doesn't
+                        # spuriously reject this column.
+                        lifted.append({"feat": col, "low": float("-inf"), "high": float("inf")})
+                manifest["feature_bounds_p01_p99"] = lifted
         manifest_out.write_text(json.dumps(manifest, indent=2, sort_keys=True))
         sys.stderr.write(f"wrote manifest {manifest_out}\n")
 

--- a/zenpicker/src/lib.rs
+++ b/zenpicker/src/lib.rs
@@ -54,7 +54,10 @@ mod model;
 pub mod rescue;
 
 pub use error::PickerError;
-pub use mask::{AllowedMask, argmin_masked, argmin_masked_top_k, reach_gate_mask};
+pub use mask::{
+    AllowedMask, FeatureBounds, argmin_masked, argmin_masked_top_k,
+    first_out_of_distribution, reach_gate_mask,
+};
 pub use model::{Activation, LayerView, Model, WeightDtype};
 pub use rescue::{RescueDecision, RescuePolicy, RescueStrategy, should_rescue};
 
@@ -241,6 +244,97 @@ impl<'a> Picker<'a> {
             adjust,
         ))
     }
+
+    /// Pick the argmin and report a *confidence* signal: the
+    /// log-bytes gap to the second-best mask-allowed entry.
+    ///
+    /// Returns `(best_idx, gap)` where `gap` is in the same units
+    /// the model emits — log-bytes for a regressor. A small `gap`
+    /// (< ~0.1, i.e. < ~10% byte difference) means the picker is
+    /// barely choosing top-1 over top-2; if your codec runs the
+    /// two-shot rescue path, a low-confidence pick is a strong
+    /// signal to verify and prepare the rescue. Codecs typically
+    /// surface `gap` on `EncodeMetrics` so imageflow / proxy
+    /// operators can scrape per-request and detect drift.
+    ///
+    /// `gap = +∞` when only one mask entry is allowed (no
+    /// second-best to compare to), `0.0` if every score ties at
+    /// the top.
+    ///
+    /// Returns `None` when the mask permits zero entries.
+    pub fn pick_with_confidence(
+        &mut self,
+        features: &[f32],
+        mask: &AllowedMask<'_>,
+        adjust: Option<CostAdjust<'_>>,
+    ) -> Result<Option<(usize, f32)>, PickerError> {
+        self.predict(features)?;
+        let top = mask::argmin_masked_top_k::<2>(&self.output, mask, adjust);
+        Ok(pick_confidence_from_top_k(&self.output, mask, adjust, top))
+    }
+
+    /// Like [`pick_with_confidence`] but operating on the bytes-log
+    /// sub-range of the hybrid-heads layout.
+    pub fn pick_with_confidence_in_range(
+        &mut self,
+        features: &[f32],
+        range: (usize, usize),
+        mask: &AllowedMask<'_>,
+        adjust: Option<CostAdjust<'_>>,
+    ) -> Result<Option<(usize, f32)>, PickerError> {
+        self.predict(features)?;
+        let (start, end) = range;
+        if end > self.output.len() || start > end {
+            return Err(PickerError::FeatureLenMismatch {
+                expected: self.output.len(),
+                got: end,
+            });
+        }
+        let slice = &self.output[start..end];
+        let top = mask::argmin_masked_top_k::<2>(slice, mask, adjust);
+        Ok(pick_confidence_from_top_k(slice, mask, adjust, top))
+    }
+}
+
+/// Convert a top-2 result into `(best_idx, gap_to_second)`.
+///
+/// `gap` is computed in the same score space `argmin_masked_top_k`
+/// used: log-space when `adjust` is `None`, raw-byte space when
+/// `adjust` is `Some` (matching what the picker's argmin actually
+/// compared). Codecs surfacing the gap to operators thus get a
+/// signal in the same units the picker chose against.
+fn pick_confidence_from_top_k(
+    scores: &[f32],
+    mask: &AllowedMask<'_>,
+    adjust: Option<CostAdjust<'_>>,
+    top: [Option<usize>; 2],
+) -> Option<(usize, f32)> {
+    let best = top[0]?;
+    let Some(second) = top[1] else {
+        // Only one mask-allowed entry — no comparison to make.
+        return Some((best, f32::INFINITY));
+    };
+    let score_at = |i: usize| -> f32 {
+        let raw = scores[i];
+        match adjust {
+            None => raw,
+            Some(CostAdjust {
+                additive_bytes,
+                per_output_offset,
+            }) => {
+                let mut bytes = mask::clamped_exp_pub(raw) + additive_bytes;
+                if let Some(off) = per_output_offset.and_then(|o| o.get(i)) {
+                    bytes += *off;
+                }
+                bytes
+            }
+        }
+    };
+    // Use mask hint to keep miri-style debug builds happy if
+    // `argmin_masked_top_k` ever returns indices outside the mask.
+    let _ = mask;
+    let gap = (score_at(second) - score_at(best)).max(0.0);
+    Some((best, gap))
 }
 
 #[cfg(test)]

--- a/zenpicker/src/mask.rs
+++ b/zenpicker/src/mask.rs
@@ -167,6 +167,61 @@ pub fn argmin_masked_top_k<const K: usize>(
     out
 }
 
+/// Inclusive low/high bounds for one input feature.
+///
+/// Codec emits a compile-time `FEATURE_BOUNDS: &[FeatureBounds]`
+/// table aligned 1:1 with the input feature vector, sourced from
+/// the bake manifest's `feature_bounds_p01_p99` field. Picker
+/// runtime calls [`first_out_of_distribution`] before
+/// [`argmin_masked`] to detect inputs the model wasn't trained on.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FeatureBounds {
+    pub low: f32,
+    pub high: f32,
+}
+
+impl FeatureBounds {
+    pub const fn new(low: f32, high: f32) -> Self {
+        Self { low, high }
+    }
+
+    /// `true` when `value` is finite and inside `[low, high]`.
+    #[inline]
+    pub fn contains(&self, value: f32) -> bool {
+        value.is_finite() && value >= self.low && value <= self.high
+    }
+}
+
+/// Index of the first feature outside its bounds, or `None` when
+/// the entire vector is in-distribution.
+///
+/// Codec calls this before [`argmin_masked`]. On `Some(i)` the
+/// caller should fall through to a known-good rescue strategy
+/// (see [`crate::RescueStrategy::KnownGoodFallback`]) rather than
+/// trust an MLP extrapolation. `bounds.len()` must equal
+/// `features.len()`; mismatched lengths panic in debug builds and
+/// short-circuit at the shorter length in release.
+///
+/// NaN / Inf in the feature vector trigger a hit just as out-of-
+/// range values do — those features can't be modeled and should
+/// always force fallback.
+pub fn first_out_of_distribution(
+    features: &[f32],
+    bounds: &[FeatureBounds],
+) -> Option<usize> {
+    debug_assert_eq!(
+        features.len(),
+        bounds.len(),
+        "feature vector length must match bounds length",
+    );
+    for (i, (f, b)) in features.iter().zip(bounds.iter()).enumerate() {
+        if !b.contains(*f) {
+            return Some(i);
+        }
+    }
+    None
+}
+
 /// Fill `out` with the per-cell allow flags derived from a row of
 /// `reach_rate` values and a runtime threshold.
 ///
@@ -203,6 +258,10 @@ pub fn reach_gate_mask(reach_rates: &[f32], threshold: f32, out: &mut [bool]) {
 
 /// `exp` with input clamped to [-30, 30] to keep training-time
 /// out-of-range predictions from producing NaN/Inf at inference.
+pub(crate) fn clamped_exp_pub(x: f32) -> f32 {
+    clamped_exp(x)
+}
+
 fn clamped_exp(x: f32) -> f32 {
     libm_exp_f32(x.clamp(-30.0, 30.0))
 }

--- a/zenpicker/src/tests.rs
+++ b/zenpicker/src/tests.rs
@@ -394,6 +394,73 @@ fn reach_gate_mask_thresholds_correctly() {
 }
 
 #[test]
+fn first_out_of_distribution_finds_first_violator() {
+    use crate::{FeatureBounds, first_out_of_distribution};
+
+    let bounds = [
+        FeatureBounds::new(0.0, 1.0),
+        FeatureBounds::new(-1.0, 1.0),
+        FeatureBounds::new(0.5, 1.5),
+    ];
+    assert_eq!(first_out_of_distribution(&[0.5, 0.0, 1.0], &bounds), None);
+    assert_eq!(first_out_of_distribution(&[0.0, -1.0, 1.5], &bounds), None);
+    assert_eq!(
+        first_out_of_distribution(&[0.5, -2.0, 1.0], &bounds),
+        Some(1)
+    );
+    assert_eq!(
+        first_out_of_distribution(&[2.0, 0.0, 100.0], &bounds),
+        Some(0)
+    );
+    assert_eq!(
+        first_out_of_distribution(&[f32::NAN, 0.0, 1.0], &bounds),
+        Some(0)
+    );
+    assert_eq!(
+        first_out_of_distribution(&[0.5, f32::INFINITY, 1.0], &bounds),
+        Some(1)
+    );
+}
+
+#[test]
+fn pick_with_confidence_returns_gap() {
+    let mut buf = alloc::vec::Vec::new();
+    write_v1_model_f32(
+        &mut buf,
+        1,
+        &[(1, 4, 0, &[0.0, 0.0, 0.0, 0.0], &[3.0, 1.0, 2.0, 0.5])],
+        0,
+    );
+    let aligned = AlignedBuf::from_slice(&buf);
+    let model = Model::from_bytes(aligned.as_bytes()).unwrap();
+    let mut picker = Picker::new(model);
+
+    let mask_all = AllowedMask::new(&[true, true, true, true]);
+    let (best, gap) = picker
+        .pick_with_confidence(&[0.0], &mask_all, None)
+        .unwrap()
+        .expect("non-empty mask");
+    assert_eq!(best, 3);
+    assert!((gap - 0.5).abs() < 1e-5, "gap={gap}");
+
+    let mask_one = AllowedMask::new(&[false, false, false, true]);
+    let (best, gap) = picker
+        .pick_with_confidence(&[0.0], &mask_one, None)
+        .unwrap()
+        .expect("one allowed entry");
+    assert_eq!(best, 3);
+    assert!(gap.is_infinite() && gap > 0.0);
+
+    let mask_none = AllowedMask::new(&[false, false, false, false]);
+    assert!(
+        picker
+            .pick_with_confidence(&[0.0], &mask_none, None)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
 fn rejects_bad_magic() {
     let mut buf = alloc::vec::Vec::new();
     write_v1_model_f32(&mut buf, 1, &[(1, 1, 0, &[1.0], &[0.0])], 0);

--- a/zenpicker/tools/README.md
+++ b/zenpicker/tools/README.md
@@ -13,10 +13,12 @@ config-name parser. Then runs these scripts against that config.
 | `train_hybrid.py` | **Recommended.** Hybrid-heads training: N categorical cells + K scalar prediction heads per cell. Codec supplies the cell taxonomy via `parse_config_name`. Flags: `--objective {size_optimal, zensim_strict}`, `--bytes-quantile`, `--reach-threshold`, `--hidden 192,192,192`, `--out-suffix` |
 | `train_distill.py` | Categorical-only distillation (legacy v1.x picker shape). Per-config HistGB teacher → small shared MLP student |
 | `train_distill_reduced.py` | Same as `train_distill.py` but with a reduced feature subset declared in the codec config |
-| `feature_ablation.py` | Per-feature importance ranking. **`--method permutation`** (default) — train once, shuffle each column, ~50× faster than LOO. `--method loo` retrains the model with each feature dropped (legacy ground truth) |
+| `feature_ablation.py` | Per-feature importance ranking. **`--method permutation`** (default) — train once, shuffle each column, ~50× faster than LOO. `--method loo` retrains the model with each feature dropped (legacy ground truth). `--strict` exits 1 on features whose Δ is below `--max-negative-delta-pp` (overfit-on-noise signal) |
 | `feature_group_ablation.py` | Group ablation (drop entire tier-aligned groups) |
 | `validate_schema.py` | Re-train production HistGB with a chosen feature subset, report held-out metrics |
 | `capacity_sweep.py` | Architecture × cross-term-recipe sweep over the student MLP |
+| `adversarial_probe.py` | Corner-case spot-check for any model JSON: zeros / huge / NaN / Inf / single-feature spike. Asserts no NaN/Inf in output, top-1/top-2 gap ≥ 0, predicted bytes plausible. Exits 1 in `--strict` |
+| `diagnose_picker.py` | Human-readable health report for any model JSON or .manifest.json. Works on legacy bakes that pre-date `safety_report` (falls back to a static MLP weight scan) |
 
 The [`tools/bake_picker.py`](../../tools/bake_picker.py) script (parent
 directory, not this one) consumes the JSON output of any of the
@@ -170,6 +172,26 @@ SAFETY_THRESHOLDS = dict(
 **The strict gate** (`--strict`, also auto-enabled when the `CI` environment variable is set) makes `train_hybrid.py` exit 1 on any violation. JSON + log are still written so reviewers can inspect; only the exit code signals failure. **CI should always run with `--strict`** so a regressed bake fails the workflow before it gets near `bake_picker.py`.
 
 `bake_picker.py` reads `safety_report.passed` and **refuses to bake** an unsafe model JSON unless `--allow-unsafe` is passed (only when the violation is intentional and reviewed). Defense in depth: the `safety_report` is also forwarded into the `.manifest.json`, so codec runtime can refuse to load too.
+
+### OOD detection (runtime gate)
+
+`train_hybrid.py` also computes per-feature distribution stats — `{min, p01, p25, p50, p75, p99, max, mean, std}` over the **training** image set — and ships them in `safety_report.diagnostics.feature_bounds`. `bake_picker.py` lifts the `(p01, p99)` pair into a top-level `manifest.feature_bounds_p01_p99` array aligned 1:1 with `feat_cols`.
+
+Codec runtime emits a compile-time `FEATURE_BOUNDS: &[zenpicker::FeatureBounds]` table from the manifest, then calls `zenpicker::first_out_of_distribution(&features, FEATURE_BOUNDS)` before `argmin_masked`. On `Some(idx)`, fall through to `RescueStrategy::KnownGoodFallback` instead of trusting an MLP extrapolation. NaN / Inf inputs always trigger the gate.
+
+### Pick confidence (runtime metric)
+
+`Picker::pick_with_confidence(features, mask, adjust)` returns `(best_idx, log_bytes_gap_to_2nd)`. A small `gap` (< ~0.1 in log space, i.e. < ~10% bytes) means the picker barely chose top-1 over top-2 — a strong signal the rescue path should verify even before encoding. Codec exposes the gap on `EncodeMetrics`; imageflow / proxy operators scrape per-request to detect drift.
+
+### Permutation-importance gate (schema cleanliness)
+
+`feature_ablation.py --strict` (auto in CI) exits 1 on any feature with `Δ < --max-negative-delta-pp` (default −0.05pp). A feature whose mean overhead *drops* when the column is shuffled is noise the model overfit on — 100% drop signal. CI should run the ablation on the same `--codec-config` that `train_hybrid.py` did and treat negative-Δ findings as a `KEEP_FEATURES` regression.
+
+### Adversarial probe + diagnose (post-bake spot-check)
+
+`adversarial_probe.py --model <bake>.json --strict` runs ~10 corner inputs (zeros, huge, NaN, Inf, single-feature spike) and asserts no NaN/Inf in output, top-1/top-2 gap ≥ 0, predicted bytes plausible. Cheap CI gate after `bake_picker.py`.
+
+`diagnose_picker.py --model <bake>.json` (or `--manifest <bake>.manifest.json`) prints a human-readable health report. Useful for reviewing a bake by eye. Falls back gracefully on legacy bakes (pre-`safety_report`) by computing a static MLP weight scan from the JSON layers.
 
 ### GBM backend choice
 

--- a/zenpicker/tools/adversarial_probe.py
+++ b/zenpicker/tools/adversarial_probe.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Adversarial / corner-case spot-check for a baked picker JSON.
+
+Runs ~10 synthetic feature vectors through the trained MLP (via the
+Python-side numpy reference, not the .bin loader — same forward pass,
+no Rust dependency) and asserts that the picker behaves sensibly:
+
+  * No NaN / Inf in any cell's predicted output
+  * No NaN / Inf in any cell's predicted log-bytes
+  * top-1 / top-2 gap is non-negative (well-defined ordering)
+  * argmin returns an in-range cell index
+  * predicted bytes (exp of log-bytes) are positive and not absurdly
+    large (catches integer-overflow-in-disguise via huge log values)
+
+Inputs are deliberately extreme:
+
+  * all-zeros (input is exactly the scaler mean → no information)
+  * all-ones  (every feature at +1 std)
+  * all-minus-ones
+  * single-feature spike (one feature huge, rest at scaler mean)
+  * NaN / Inf injection (every input feature flipped to NaN, then to
+    Inf) — the picker must not crash or silently produce NaN output;
+    the codec is expected to gate on `feature_in_distribution` first
+    and never feed NaN to the picker, but defense-in-depth here
+    catches future regressions
+
+Exits non-zero on any failure so CI can run it as a post-bake gate.
+
+Usage:
+
+    python3 adversarial_probe.py --model benchmarks/<bake>.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def relu_forward(x: np.ndarray, layers: list[dict]) -> np.ndarray:
+    """ReLU MLP forward pass — final layer identity."""
+    a = x
+    last = len(layers) - 1
+    for i, layer in enumerate(layers):
+        W = np.asarray(layer["W"], dtype=np.float64)
+        b = np.asarray(layer["b"], dtype=np.float64)
+        z = a @ W + b
+        a = z if i == last else np.maximum(z, 0.0)
+    return a
+
+
+def standardize(x: np.ndarray, mean: np.ndarray, scale: np.ndarray) -> np.ndarray:
+    """Match StandardScaler — guard against zero-scale columns."""
+    safe_scale = np.where(scale == 0.0, 1.0, scale)
+    return (x - mean) / safe_scale
+
+
+def adversarial_inputs(n_inputs: int) -> list[tuple[str, np.ndarray]]:
+    """Synthesize corner-case input vectors.
+
+    `n_inputs` is the standardized input dim (post-feature-engineering;
+    matches `model["n_inputs"]`). Inputs are emitted in the *post-
+    scaler* space — i.e., what gets fed into layer 0 — so we can
+    sanity-check the inference math without re-implementing the
+    feature-engineering pipeline.
+    """
+    cases: list[tuple[str, np.ndarray]] = []
+    cases.append(("all_zeros", np.zeros(n_inputs, dtype=np.float64)))
+    cases.append(("all_ones", np.ones(n_inputs, dtype=np.float64)))
+    cases.append(("all_minus_ones", -np.ones(n_inputs, dtype=np.float64)))
+    cases.append(("first_feature_huge_pos", np.array([1e3] + [0.0] * (n_inputs - 1))))
+    cases.append(("first_feature_huge_neg", np.array([-1e3] + [0.0] * (n_inputs - 1))))
+    cases.append(("last_feature_huge_pos", np.array([0.0] * (n_inputs - 1) + [1e3])))
+    cases.append(("alternating_signs", np.array([(-1.0) ** i for i in range(n_inputs)])))
+    cases.append(("nan_first", np.array([float("nan")] + [0.0] * (n_inputs - 1))))
+    cases.append(("inf_first", np.array([float("inf")] + [0.0] * (n_inputs - 1))))
+    cases.append(("neg_inf_first", np.array([float("-inf")] + [0.0] * (n_inputs - 1))))
+    return cases
+
+
+def check_output(
+    name: str,
+    output: np.ndarray,
+    n_cells: int | None,
+    accept_nan_propagation: bool,
+) -> list[str]:
+    """Validate one inference output. Returns a list of failure
+    messages — empty list means the case passed."""
+    failures: list[str] = []
+    if not np.isfinite(output).all():
+        if not accept_nan_propagation:
+            failures.append(
+                f"non-finite output for case '{name}' "
+                f"(any-NaN={bool(np.isnan(output).any())}, "
+                f"any-Inf={bool(np.isinf(output).any())})"
+            )
+        # Even when NaN propagation is acceptable (NaN-input cases),
+        # we still want to confirm it's *deterministic* NaN — not
+        # half-NaN that would corrupt argmin silently. Skip further
+        # checks for this case if the output is fully non-finite.
+        return failures
+
+    # Bytes-log subrange or full output: argmin must be in range and
+    # the implied byte count must be positive and bounded.
+    bytes_log = output[:n_cells] if n_cells is not None else output
+    if bytes_log.size == 0:
+        failures.append(f"zero-length bytes_log for case '{name}'")
+        return failures
+    sorted_log = np.sort(bytes_log)
+    gap = float(sorted_log[1] - sorted_log[0]) if sorted_log.size >= 2 else float("inf")
+    if math.isnan(gap) or gap < 0.0:
+        failures.append(f"negative top-1/top-2 gap {gap:.4f} for '{name}'")
+    bytes_predicted = np.exp(np.clip(bytes_log, -30.0, 30.0))
+    if not (bytes_predicted >= 0.0).all():
+        failures.append(f"negative predicted bytes for '{name}'")
+    if bytes_predicted.max() > 1e30:
+        failures.append(
+            f"predicted bytes {bytes_predicted.max():.3e} too large for '{name}' "
+            "(check log-bytes magnitudes; suggests broken scaling)"
+        )
+    return failures
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, type=Path, help="trained model JSON")
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Auto-enabled in CI. Exit code 1 on any failure.",
+    )
+    args = ap.parse_args()
+    model = json.loads(args.model.read_text())
+    n_inputs = int(model["n_inputs"])
+    layers = model["layers"]
+    n_cells = (
+        model.get("hybrid_heads_manifest", {}).get("n_cells")
+        or int(model.get("n_outputs", 0))
+        or None
+    )
+    mean = np.asarray(model["scaler_mean"], dtype=np.float64)
+    scale = np.asarray(model["scaler_scale"], dtype=np.float64)
+
+    cases = adversarial_inputs(n_inputs)
+    sys.stderr.write(
+        f"adversarial_probe: model={args.model} n_inputs={n_inputs} "
+        f"n_cells={n_cells} cases={len(cases)}\n"
+    )
+
+    total_fail = 0
+    for name, raw in cases:
+        accept_nan = "nan" in name or "inf" in name
+        # Apply the standardizer in the same way training did.
+        x = standardize(raw, mean, scale).reshape(1, -1)
+        output = relu_forward(x, layers).ravel()
+        fails = check_output(name, output, n_cells, accept_nan_propagation=accept_nan)
+        status = "ok" if not fails else "FAIL"
+        sys.stderr.write(f"  {status:>4}  {name:30s}\n")
+        for f in fails:
+            sys.stderr.write(f"        • {f}\n")
+        total_fail += len(fails)
+
+    if total_fail:
+        sys.stderr.write(
+            f"\nadversarial_probe: {total_fail} failure(s) across "
+            f"{len(cases)} cases\n"
+        )
+        return 1 if args.strict else 0
+    sys.stderr.write(f"\n✓ adversarial_probe: all {len(cases)} cases passed\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zenpicker/tools/diagnose_picker.py
+++ b/zenpicker/tools/diagnose_picker.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Human-readable health report for any baked picker artifact.
+
+Reads either a training-side JSON (with `safety_report` if produced
+by current train_hybrid.py) or a manifest JSON next to a `.bin`
+(with the lifted `safety_report` block from `bake_picker.py`), and
+prints the diagnostics block in a form that's quick to read at a
+glance.
+
+Falls back gracefully on legacy bakes that pre-date `safety_report`:
+prints what's there (architecture, schema_hash, config count) plus
+a static MLP weight scan computed from the JSON layers themselves.
+
+Usage:
+
+    python3 diagnose_picker.py --model benchmarks/<bake>.json
+    python3 diagnose_picker.py --manifest models/<picker>.manifest.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def _format_pct(x: float | None) -> str:
+    if x is None or (isinstance(x, float) and math.isnan(x)):
+        return "—"
+    return f"{x:.2f}%"
+
+
+def _format_float(x: float | None, fmt: str = ".4f") -> str:
+    if x is None or (isinstance(x, float) and math.isnan(x)):
+        return "—"
+    return format(x, fmt)
+
+
+def diagnose_legacy(model: dict) -> None:
+    """Compute a minimal health report for a JSON without safety_report."""
+    layers = model.get("layers", [])
+    n_inputs = model.get("n_inputs")
+    n_outputs = model.get("n_outputs")
+    n_cells = model.get("hybrid_heads_manifest", {}).get("n_cells")
+    print(f"  n_inputs:  {n_inputs}")
+    print(f"  n_outputs: {n_outputs}")
+    if n_cells is not None:
+        print(f"  n_cells:   {n_cells}  (hybrid heads: {len(layers)} layers)")
+
+    print("\n  Static MLP weight scan:")
+    for i, layer in enumerate(layers):
+        W = np.asarray(layer["W"], dtype=np.float64)
+        b = np.asarray(layer["b"], dtype=np.float64)
+        nan_w = bool(np.isnan(W).any())
+        inf_w = bool(np.isinf(W).any())
+        absw = np.abs(W).flatten()
+        med = float(np.median(absw)) if absw.size else 0.0
+        mx = float(absw.max()) if absw.size else 0.0
+        ratio = mx / max(med, 1e-12)
+        flag = "  ⚠" if nan_w or inf_w or ratio > 1000.0 else ""
+        print(
+            f"    layer {i}: shape={W.shape}, |W| max/med={mx:.3f}/{med:.3f} "
+            f"ratio={ratio:.1f}, |b| max={float(np.abs(b).max()):.3f}, "
+            f"nan_in_W={nan_w}, inf_in_W={inf_w}{flag}"
+        )
+
+
+def render_report(report: dict) -> None:
+    """Pretty-print a `safety_report` block."""
+    passed = report.get("passed")
+    icon = "✓" if passed else "⚠"
+    print(f"\n  Safety: {icon} {'PASSED' if passed else 'FAILED'}")
+    violations = report.get("violations") or []
+    if violations:
+        print(f"\n  Violations ({len(violations)}):")
+        for v in violations:
+            print(f"    • {v}")
+
+    diag = report.get("diagnostics") or {}
+    argmin = diag.get("argmin") or {}
+    train = argmin.get("train") or {}
+    val = argmin.get("val") or {}
+    if val:
+        gap = (val.get("mean_pct") or 0.0) - (train.get("mean_pct") or 0.0)
+        print("\n  Argmin metrics:")
+        print(
+            f"    train: mean={_format_pct(train.get('mean_pct'))}  "
+            f"argmin_acc={_format_pct((train.get('argmin_acc') or 0) * 100)}  "
+            f"p99={_format_pct(train.get('p99_pct'))}  max={_format_pct(train.get('max_pct'))}"
+        )
+        print(
+            f"    val:   mean={_format_pct(val.get('mean_pct'))}  "
+            f"argmin_acc={_format_pct((val.get('argmin_acc') or 0) * 100)}  "
+            f"p99={_format_pct(val.get('p99_pct'))}  max={_format_pct(val.get('max_pct'))}"
+        )
+        print(f"    train→val gap: {gap:+.2f}pp")
+
+    by_zq = diag.get("by_zq") or {}
+    if by_zq:
+        print("\n  Per-zq breakdown (top 5 worst by p99):")
+        ordered = sorted(
+            by_zq.items(),
+            key=lambda kv: kv[1].get("p99_pct", 0.0),
+            reverse=True,
+        )
+        for zq, m in ordered[:5]:
+            print(
+                f"    zq={zq:>3}  n={m.get('n', 0):>4}  "
+                f"mean={_format_pct(m.get('mean_pct'))}  "
+                f"p90={_format_pct(m.get('p90_pct'))}  "
+                f"p99={_format_pct(m.get('p99_pct'))}  "
+                f"max={_format_pct(m.get('max_pct'))}"
+            )
+
+    by_size = diag.get("by_size") or {}
+    if by_size:
+        print("\n  Per-size-class breakdown:")
+        for sz, m in sorted(by_size.items()):
+            print(
+                f"    {sz:8s}  n={m.get('n', 0):>4}  "
+                f"mean={_format_pct(m.get('mean_pct'))}  "
+                f"p99={_format_pct(m.get('p99_pct'))}  "
+                f"max={_format_pct(m.get('max_pct'))}"
+            )
+
+    worst = diag.get("worst_case") or []
+    if worst:
+        print(f"\n  Worst-case rows (top {min(len(worst), 5)}):")
+        for w in worst[:5]:
+            print(
+                f"    {w.get('overhead_pct', 0):.1f}%  "
+                f"zq={w.get('zq')}  size={w.get('size_class')}  "
+                f"pick={w.get('pick')}  best={w.get('actual_best')}"
+            )
+
+    per_cell = diag.get("per_cell") or []
+    if per_cell:
+        print("\n  Per-cell calibration (top 5 by |delta|):")
+        ordered = sorted(
+            per_cell,
+            key=lambda c: abs(c.get("calibration_delta") or 0.0),
+            reverse=True,
+        )
+        for c in ordered[:5]:
+            d = c.get("calibration_delta")
+            print(
+                f"    cell {c.get('cell'):>2}: {c.get('label', '?'):30s}  "
+                f"n_train_rows={c.get('n_val_reach_rows', 0):>4}  "
+                f"n_member_configs={c.get('n_member_configs', 0):>2}  "
+                f"calibration={_format_float(d, '+.3f')}"
+            )
+
+    mlp = diag.get("mlp") or {}
+    if mlp:
+        print("\n  MLP health:")
+        print(
+            f"    dead neurons: {mlp.get('n_dead_neurons', 0)}/"
+            f"{mlp.get('n_total_hidden_neurons', 0)} "
+            f"({(mlp.get('dead_neuron_fraction') or 0) * 100:.1f}%)"
+        )
+        print(f"    max layer weight ratio: {mlp.get('max_layer_weight_ratio', 0):.0f}")
+        print(
+            f"    nan_in_weights={mlp.get('nan_in_weights')}  "
+            f"inf_in_weights={mlp.get('inf_in_weights')}  "
+            f"nan_in_predictions={mlp.get('nan_in_predictions')}"
+        )
+
+    fb = diag.get("feature_bounds") or {}
+    if fb:
+        print(f"\n  Feature bounds: {len(fb)} feature(s) with [p01, p99] recorded")
+        # Show 3 most-skewed (largest std/range deviation from mean)
+        skewed = sorted(
+            (
+                (name, s)
+                for name, s in fb.items()
+                if s.get("std") is not None and s.get("p99") is not None
+            ),
+            key=lambda kv: kv[1]["p99"] - kv[1]["p01"],
+            reverse=True,
+        )
+        for name, s in skewed[:3]:
+            print(
+                f"    {name:30s}  range[{_format_float(s.get('p01'), '+.3f')}, "
+                f"{_format_float(s.get('p99'), '+.3f')}]  "
+                f"mean={_format_float(s.get('mean'), '+.3f')}  "
+                f"std={_format_float(s.get('std'), '.3f')}"
+            )
+
+    rs = diag.get("reach_safety") or {}
+    if rs.get("by_zq"):
+        n_zq = len(rs["by_zq"])
+        threshold = rs.get("threshold", 0.99)
+        # Worst zq band by safe-cell count
+        ordered = sorted(
+            rs["by_zq"].items(),
+            key=lambda kv: sum(1 for s in kv[1].get("safe", []) if s),
+        )
+        if ordered:
+            worst_zq, worst_m = ordered[0]
+            n_safe = sum(1 for s in worst_m.get("safe", []) if s)
+            print(
+                f"\n  Reach gate (threshold={threshold}): {n_zq} zq bands, "
+                f"worst zq={worst_zq} has only {n_safe} safe cell(s)"
+            )
+
+    thresholds = report.get("thresholds")
+    if thresholds:
+        print("\n  Thresholds in effect:")
+        for k, v in sorted(thresholds.items()):
+            print(f"    {k}: {v}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    grp = ap.add_mutually_exclusive_group(required=True)
+    grp.add_argument("--model", type=Path, help="training-side model JSON")
+    grp.add_argument("--manifest", type=Path, help=".manifest.json next to a .bin")
+    args = ap.parse_args()
+
+    path = args.model or args.manifest
+    src = json.loads(path.read_text())
+    print(f"diagnose_picker: {path}")
+    print("-" * 70)
+
+    sr = src.get("safety_report")
+    if not sr:
+        print("  (legacy bake — no `safety_report` block; printing static info)")
+        diagnose_legacy(src)
+        return 0
+
+    render_report(sr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zenpicker/tools/feature_ablation.py
+++ b/zenpicker/tools/feature_ablation.py
@@ -33,6 +33,7 @@ import csv
 import importlib
 import json
 import math
+import os
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -323,7 +324,32 @@ def main():
         help="Permutation repeats per feature (averaged). Default 3 — high "
         "enough to denoise small datasets without inflating wall-time.",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with code 1 when any feature has Δ < --max-negative-delta-pp. "
+        "Auto-enabled when the CI environment variable is set. A feature whose "
+        "Δ is *negative* under permutation importance — i.e., shuffling that "
+        "feature *improves* the picker — is noise the model overfit; ranking "
+        "negatives indicates schema needs pruning before ship.",
+    )
+    parser.add_argument(
+        "--allow-unsafe",
+        action="store_true",
+        help="Override --strict / CI for intentionally noisy features.",
+    )
+    parser.add_argument(
+        "--max-negative-delta-pp",
+        type=float,
+        default=-0.05,
+        help="Threshold (in pp) below which a Δ counts as a strict-mode "
+        "violation. Default -0.05pp — features that improve the picker by "
+        "more than 0.05pp when shuffled are flagged. Set to e.g. -0.20 for "
+        "looser tolerance.",
+    )
     args = parser.parse_args()
+    is_ci = bool(os.environ.get("CI"))
+    strict = (args.strict or is_ci) and not args.allow_unsafe
     if args.codec_config:
         load_codec_config(args.codec_config)
     sys.stderr.write(f"Loading {PARETO}...\n")
@@ -424,6 +450,33 @@ def main():
     for name, m in loo_sorted[-5:]:
         sys.stderr.write(f"    {name}: drop → {m['mean_pct']:.2f}% (Δ {m['mean_pct'] - baseline['mean_pct']:+.2f}pp)\n")
 
+    # ============ Strict-gate: flag negative-Δ features ============
+    # A feature whose permutation Δ is negative is *noise the model
+    # overfit*. Listing them is a 100% should-be-dropped signal that
+    # the schema needs pruning before ship.
+    negatives = []
+    for name, m in loo_sorted:
+        delta = m["mean_pct"] - baseline["mean_pct"]
+        if delta < args.max_negative_delta_pp:
+            negatives.append({"feature": name, "delta_pp": delta})
+    if negatives:
+        sys.stderr.write(
+            "\n" + "=" * 70 + "\n"
+            f"  ⚠ {len(negatives)} FEATURE(S) IMPROVE THE PICKER WHEN SHUFFLED — overfit signal\n"
+            + "=" * 70 + "\n"
+        )
+        for n in negatives:
+            sys.stderr.write(
+                f"  • {n['feature']:35s} Δ {n['delta_pp']:+.2f}pp\n"
+            )
+        sys.stderr.write(
+            "=" * 70 + "\n"
+            "  Drop these from KEEP_FEATURES and retrain. Threshold: "
+            f"{args.max_negative_delta_pp:+.2f}pp.\n"
+        )
+    else:
+        sys.stderr.write("\n✓ No features improve the picker when shuffled.\n")
+
     # ============ Phase 3: forward greedy (optional) ============
     greedy_curve = []
     if SKIP_GREEDY:
@@ -514,6 +567,15 @@ def main():
         w(f"{entry['k']:>3d} {m['mean_pct']:>9.2f}%  {m['argmin_acc']:>10.1%}   +{added}")
 
     OUT_LOG.write_text("\n".join(lines))
+
+    # Strict-gate exit. Logs already written for inspection; only the
+    # exit code signals failure.
+    if negatives and strict:
+        sys.stderr.write(
+            f"\nstrict mode: exiting 1 with {len(negatives)} negative-Δ feature(s). "
+            "Re-run with --allow-unsafe to override.\n"
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/zenpicker/tools/train_hybrid.py
+++ b/zenpicker/tools/train_hybrid.py
@@ -510,6 +510,50 @@ DEFAULT_SAFETY_THRESHOLDS = dict(
 )
 
 
+def compute_feature_bounds(feats, train_keys, feat_cols):
+    """Per-feature distribution stats over the **training** image set.
+
+    Computed once at bake time and shipped in the manifest so codecs
+    can detect out-of-distribution inputs at runtime and fall through
+    to a `KnownGoodFallback` rescue rather than letting the MLP
+    extrapolate silently.
+
+    Each entry is a dict with `min, p01, p25, p50, p75, p99, max,
+    mean, std` — codec picks which pair to compile into its
+    `FEATURE_BOUNDS` const. Default recommendation: `(p01, p99)` so
+    the gate fires only on truly extreme inputs (≈2% miss rate at
+    train-distribution boundaries by construction).
+    """
+    keys_seen = [k for k in train_keys if k in feats]
+    if not keys_seen:
+        return {}
+    arr = np.stack([feats[k] for k in keys_seen]).astype(np.float64)
+    out = {}
+    for i, col in enumerate(feat_cols):
+        v = arr[:, i]
+        v_finite = v[np.isfinite(v)]
+        if v_finite.size == 0:
+            out[col] = {
+                "min": None, "p01": None, "p25": None, "p50": None,
+                "p75": None, "p99": None, "max": None,
+                "mean": None, "std": None, "n": 0,
+            }
+            continue
+        out[col] = {
+            "min": float(v_finite.min()),
+            "p01": float(np.percentile(v_finite, 1)),
+            "p25": float(np.percentile(v_finite, 25)),
+            "p50": float(np.percentile(v_finite, 50)),
+            "p75": float(np.percentile(v_finite, 75)),
+            "p99": float(np.percentile(v_finite, 99)),
+            "max": float(v_finite.max()),
+            "mean": float(v_finite.mean()),
+            "std": float(v_finite.std()),
+            "n": int(v_finite.size),
+        }
+    return out
+
+
 def stratify_overheads(per_row):
     """Group per-row overhead entries by (zq, size_class). Returns
     {zq: {size_class: stats_dict}} and a flat per-zq aggregate."""
@@ -1095,6 +1139,11 @@ def main():
     per_cell = per_cell_diagnostics(cells, pred_bytes, bl_va, rch_va, n_cells)
     mlp_health = scan_mlp_weights(student, Xe_va_s)
 
+    # Per-feature distribution bounds over the train split — shipped
+    # in the manifest so codecs can do runtime OOD checks.
+    train_keys = {(meta[i][0], meta[i][1]) for i in tr}
+    feature_bounds = compute_feature_bounds(feats, train_keys, feat_cols)
+
     # --- Per-zq reach-rate gate (zensim_strict only; recorded
     # always so the manifest is shape-stable across profiles)
     reach_safety = compute_reach_safe_cells(
@@ -1110,6 +1159,7 @@ def main():
         "worst_case": worst,
         "per_cell": per_cell,
         "mlp": mlp_health,
+        "feature_bounds": feature_bounds,
         "reach_safety": reach_safety,
     }
     thresholds = dict(DEFAULT_SAFETY_THRESHOLDS)


### PR DESCRIPTION
Stacked on #34 (safety-gates). None of these touch the codec-agnostic plumbing the other agent is refactoring — they sit alongside.

## What lands

| # | Pathology | Surface |
|---|---|---|
| 3 | OOD detection | `train_hybrid` per-feature distribution stats → manifest `feature_bounds_p01_p99` → `zenpicker::first_out_of_distribution` runtime gate. Codec falls through to `KnownGoodFallback` on out-of-range / NaN / Inf inputs |
| 4 | Pick confidence | `Picker::pick_with_confidence` returns `(best, log_bytes_gap_to_2nd)`. Small gap = uncertain pick. Free since top_k is already cached for rescue |
| 8 | Permutation-importance gate | `feature_ablation.py --strict` (auto-CI) exits 1 on Δ < `--max-negative-delta-pp` (default −0.05pp) — features the model overfit on |
| 9 | Adversarial probe + diagnose | `tools/adversarial_probe.py` runs ~10 corner inputs (zero/max/NaN/Inf/spike), asserts output sane. `tools/diagnose_picker.py` prints human-readable health report on any JSON or manifest, falls back to static weight scan on legacy bakes |

## Tests

- 28 picker unit tests pass (added `first_out_of_distribution_finds_first_violator`, `pick_with_confidence_returns_gap`)
- `adversarial_probe.py` runs 10/10 clean against the shipped v2.1 bake
- `diagnose_picker.py` validated against the v2.1 JSON — surfaces the zq=94+tiny worst-case the safety-gates PR caught