### PR TITLE
fix(zenpicker): cargo fmt after FeatureBounds additions

### DIFF
--- a/zenpicker/src/lib.rs
+++ b/zenpicker/src/lib.rs
@@ -55,8 +55,8 @@ pub mod rescue;
 
 pub use error::PickerError;
 pub use mask::{
-    AllowedMask, FeatureBounds, argmin_masked, argmin_masked_top_k,
-    first_out_of_distribution, reach_gate_mask,
+    AllowedMask, FeatureBounds, argmin_masked, argmin_masked_top_k, first_out_of_distribution,
+    reach_gate_mask,
 };
 pub use model::{Activation, LayerView, Model, WeightDtype};
 pub use rescue::{RescueDecision, RescuePolicy, RescueStrategy, should_rescue};

--- a/zenpicker/src/mask.rs
+++ b/zenpicker/src/mask.rs
@@ -205,10 +205,7 @@ impl FeatureBounds {
 /// NaN / Inf in the feature vector trigger a hit just as out-of-
 /// range values do — those features can't be modeled and should
 /// always force fallback.
-pub fn first_out_of_distribution(
-    features: &[f32],
-    bounds: &[FeatureBounds],
-) -> Option<usize> {
+pub fn first_out_of_distribution(features: &[f32], bounds: &[FeatureBounds]) -> Option<usize> {
     debug_assert_eq!(
         features.len(),
         bounds.len(),


### PR DESCRIPTION
## Summary

PR #35 (four pathology seatbelts) added `FeatureBounds` + `first_out_of_distribution` to `zenpicker/src/lib.rs` and `zenpicker/src/mask.rs` without running `cargo fmt`. The post-merge `main` CI run caught it:

- Failing run: https://github.com/imazen/zenanalyze/actions/runs/25143395239
- Failing job: `Test (ubuntu-latest / experimental,composites)` (job 73697976539)

The `Format` step is gated to `ubuntu-latest / experimental,composites` only (see `.github/workflows/ci.yml`), which is why the other three ubuntu cells passed and only this one failed. The pre-merge run on PR #35 (run 25143361166) had the same failure but it landed anyway.

## Fix

`cargo fmt` — purely cosmetic re-export list reflow and function signature reflow. No semantic changes. 5 LoC delta.

## Test plan

- [x] `cargo fmt --check` clean locally
- [ ] CI's Format step passes on `ubuntu-latest / experimental,composites`