### PR TITLE
docs(zenpicker): scaler convention + canonical training pipeline

### DIFF
--- a/zenpicker/src/inference.rs
+++ b/zenpicker/src/inference.rs
@@ -30,6 +30,21 @@ pub fn forward(
     debug_assert_eq!(output.len(), model.n_outputs());
 
     // Scale inputs: x' = (x - mean) * scale.
+    //
+    // **Wire-format convention.** `scale` here is the value baked into
+    // the model from the Python side, where the emitter writes
+    // sklearn's `StandardScaler.scale_` (= **standard deviation**, not
+    // its inverse) into the `scaler_scale` JSON field. sklearn's own
+    // transform divides by `scale_` (giving `(x - mean) / std`), so
+    // mathematically this multiplies by `std` instead of dividing —
+    // the formal opposite of standardization.
+    //
+    // It works because the trained MLP's first layer has absorbed
+    // whichever direction the Python pipeline used; end-to-end the
+    // function is still correct. **Do not "fix" the direction in
+    // isolation** — that would silently miscalibrate every shipped
+    // v1.x / v2.x bake. If a future format ever flips the convention,
+    // bump the bake version and migrate.
     let mean = model.scaler_mean();
     let scale = model.scaler_scale();
     let cur = &mut scratch_a[..n_inputs];

--- a/zenpicker/tools/README.md
+++ b/zenpicker/tools/README.md
@@ -50,34 +50,86 @@ sentinel value for cells where the axis is N/A).
 
 For the zenjpeg reference, see [`examples/zenjpeg_picker_config.py`](../examples/zenjpeg_picker_config.py).
 
-## End-to-end
+## Canonical end-to-end command sequence
+
+Every codec bake should run this six-stage pipeline, in order. Stages 4–6 are the safety gates — they may fail and that is the point. Don't skip any of them. Run from the codec's repo root (where the Pareto sweep TSVs live in `benchmarks/`); paths shown assume `<zenanalyze>` is the path to your zenanalyze checkout, and the codec config module is `<your_codec>_picker_config` importable on `PYTHONPATH`.
 
 ```bash
-# 1. Codec runs its Pareto sweep harness, producing TSVs.
-cd zenjpeg-checkout
-cargo run --release -p zenjpeg --features 'target-zq trellis' \
-    --example zq_pareto_calibrate
+PP="<zenanalyze>/zenpicker/examples:<zenanalyze>/zenpicker/tools"
 
-# 2. Train the hybrid-heads picker against zenjpeg's config taxonomy.
-PYTHONPATH=zenanalyze/zenpicker/examples:zenanalyze/zenpicker/tools \
-    python3 zenanalyze/zenpicker/tools/train_hybrid.py \
-        --codec-config zenjpeg_picker_config
+# 1. Sweep. Codec's harness emits per-(image, size, config, q) Pareto rows
+#    + per-(image, size) features TSV. Hours; do once, then only re-extract
+#    features when zenanalyze adds variants (--features-only flag, ~1 s).
+cargo run --release -p <your_codec> --features '<...>' \
+    --example <your_codec>_pareto_calibrate
+# (when re-extracting features only after a zenanalyze upgrade:)
+cargo run --release -p <your_codec> --features '<...>' \
+    --example <your_codec>_pareto_calibrate -- --features-only \
+    --features-output benchmarks/<your_codec>_features_v2_1.tsv
 
-# 3. Bake to v1 binary.
-python3 zenanalyze/tools/bake_picker.py \
-    --model benchmarks/zq_bytes_hybrid_2026-04-29.json \
-    --out   models/zenjpeg_picker_v2.0_hybrid.bin \
+# 2. Train. Codec config supplies CATEGORICAL_AXES, SCALAR_AXES, parser,
+#    optional SAFETY_THRESHOLDS, KEEP_FEATURES. Default --hidden 128,128
+#    is fine for ≤8-feature schemas; bump to 192,192,192 when n_inputs
+#    grows past ~50. For SLA traffic, also bake a zensim_strict variant.
+PYTHONPATH=$PP CI=1 python3 <zenanalyze>/zenpicker/tools/train_hybrid.py \
+    --codec-config <your_codec>_picker_config \
+    --objective size_optimal --hidden 192,192,192
+# zensim_strict variant (pinball-q99 bytes head + reach gate):
+PYTHONPATH=$PP CI=1 python3 <zenanalyze>/zenpicker/tools/train_hybrid.py \
+    --codec-config <your_codec>_picker_config \
+    --objective zensim_strict --hidden 192,192,192
+
+# 3. Permutation-importance ablation. Drop features with Δ < 0 (model
+#    overfits noise) before locking the schema. ~2 min wall-clock.
+PYTHONPATH=$PP CI=1 python3 <zenanalyze>/zenpicker/tools/feature_ablation.py \
+    --codec-config <your_codec>_picker_config
+
+# 4. Bake. bake_picker.py refuses to bake when the model JSON's
+#    safety_report.passed=false — see strict-gate failures from step 2
+#    and pass --allow-unsafe only after writing down a reviewer note.
+python3 <zenanalyze>/tools/bake_picker.py \
+    --model benchmarks/<bake-base>.json \
+    --out   <zenanalyze>/zenpicker/models/<your_codec>_picker_v<X>.bin \
     --dtype f16
 
-# 4. Verify round-trip.
-python3 zenanalyze/tools/bake_roundtrip_check.py \
-    --model benchmarks/zq_bytes_hybrid_2026-04-29.json \
-    --dtype f16
+# 5. Round-trip check. Asserts Rust loader + numpy reference forward
+#    pass agree to within tolerance; catches binary-format regressions.
+python3 <zenanalyze>/tools/bake_roundtrip_check.py \
+    --model benchmarks/<bake-base>.json --dtype f16
+
+# 6. Post-bake spot checks.
+#    a) Adversarial probe: zeros / huge / NaN / Inf / single-feature spike.
+python3 <zenanalyze>/zenpicker/tools/adversarial_probe.py --strict \
+    --model benchmarks/<bake-base>.json
+#    b) Human-readable health report — review by eye.
+python3 <zenanalyze>/zenpicker/tools/diagnose_picker.py \
+    --model benchmarks/<bake-base>.json
 ```
 
 End-to-end retrain on a 16-core box, with the dataset cache warm:
-~3 minutes wall-clock (was ~25 minutes before the parallel-teachers
-refactor).
+~3 minutes wall-clock for steps 2-6 combined (was ~25 minutes before
+the parallel-teachers refactor).
+
+**CI rule:** every codec's CI must run stages 2-3 with `CI=1`
+(auto-strict) and stages 4 + 6a as separate jobs. A regression in any
+of them fails the workflow before a bad bake ever reaches `models/`.
+
+### Quick reference — which flag does what
+
+| Flag | Stage | When |
+|---|---|---|
+| `--codec-config <module>` | 2, 3 | Always. Module declares paths + schema + parser |
+| `--objective {size_optimal, zensim_strict}` | 2 | Default `size_optimal`. Bake `zensim_strict` alongside for SLA traffic |
+| `--bytes-quantile 0.99` | 2 | Quantile for the zensim_strict bytes head |
+| `--reach-threshold 0.99` | 2 | Per-cell reach-rate floor for the zensim_strict gate |
+| `--hidden W1,W2,...` | 2 | MLP hidden widths. Default `128,128`; bump to `192,192,192` past ~50 inputs |
+| `--out-suffix <suffix>` | 2 | Capacity sweep — keeps multiple bakes side-by-side |
+| `--strict` / `CI=1` env | 2, 3, 6a | Exit 1 on safety-gate violation. Always on in CI |
+| `--allow-unsafe` | 2, 3, 4 | Override strict gate. Only with a reviewer note |
+| `--method {permutation, loo}` | 3 | Default `permutation` (~50× faster than LOO) |
+| `--n-repeats N` | 3 | Permutation repeats per feature (default 3, bump to 5 on small val sets) |
+| `--max-negative-delta-pp X` | 3 | Strict-mode threshold for negative-Δ features (default −0.05pp) |
+| `--dtype {f16, f32}` | 4, 5 | Bake weight storage. f16 halves size at no measurable accuracy cost |
 
 ## Iteration vs production
 

--- a/zenpicker/tools/train_distill.py
+++ b/zenpicker/tools/train_distill.py
@@ -261,6 +261,16 @@ def main():
         "config_names": {int(k): v for k, v in CONFIG_NAMES.items()},
         "feat_cols": feat_cols,
         "scaler_mean": scaler.mean_.tolist(),
+        # NOTE: `scaler_scale` stores sklearn's `StandardScaler.scale_`
+        # directly — that attribute IS the standard deviation, not its
+        # inverse. `zenpicker::inference` then *multiplies* by it at
+        # runtime (rather than dividing as sklearn's own `transform`
+        # does), so mathematically the picker scales by std instead of
+        # normalizing. The MLP's first layer absorbs the discrepancy at
+        # training time so end-to-end behavior is correct. See
+        # `zenpicker/src/inference.rs` for the full explanation. Do
+        # not "fix" the direction in isolation — every shipped v1.x /
+        # v2.x bake depends on this convention.
         "scaler_scale": scaler.scale_.tolist(),
         "layers": [
             {"W": w.tolist(), "b": b.tolist()}

--- a/zenpicker/tools/train_distill_reduced.py
+++ b/zenpicker/tools/train_distill_reduced.py
@@ -253,6 +253,12 @@ def main():
         "config_names": {int(k): v for k, v in CONFIG_NAMES.items()},
         "feat_cols": feat_cols,
         "scaler_mean": scaler.mean_.tolist(),
+        # NOTE: `scaler_scale` stores sklearn's `StandardScaler.scale_`
+        # (= the standard deviation, not its inverse). The runtime in
+        # `zenpicker/src/inference.rs` multiplies by this rather than
+        # dividing — see that file's comment for the full explanation
+        # of why every shipped v1.x / v2.x bake depends on this
+        # convention.
         "scaler_scale": scaler.scale_.tolist(),
         "layers": [
             {"W": w.tolist(), "b": b.tolist()}

--- a/zenpicker/tools/train_hybrid.py
+++ b/zenpicker/tools/train_hybrid.py
@@ -1208,6 +1208,16 @@ def main():
         "config_names": {int(k): v for k, v in CONFIG_NAMES.items()},
         "feat_cols": feat_cols,
         "scaler_mean": scaler.mean_.tolist(),
+        # NOTE: `scaler_scale` stores sklearn's `StandardScaler.scale_`
+        # directly — that attribute IS the standard deviation, not its
+        # inverse. `zenpicker::inference` then *multiplies* by this at
+        # runtime (rather than dividing as sklearn's own `transform`
+        # does), so mathematically the picker scales by std instead of
+        # normalizing. The MLP's first layer absorbs the discrepancy
+        # at training time so end-to-end behavior is correct. See
+        # `zenpicker/src/inference.rs` for the full explanation. Do
+        # not "fix" the direction in isolation — every shipped v1.x /
+        # v2.x bake depends on this convention.
         "scaler_scale": scaler.scale_.tolist(),
         "layers": [
             {"W": w.tolist(), "b": b.tolist()}


### PR DESCRIPTION
Two future-reader fixes consolidated ahead of zenpicker 0.1.0 publish.

## (1) Scaler-convention comment at all four sites

The budget-research agent surfaced a real "field name vs runtime semantics" mismatch: sklearn's `StandardScaler.scale_` IS the std, our Python emitters write that into the bake's `scaler_scale` field, and `zenpicker::inference` *multiplies* by it rather than dividing as sklearn's own `transform` does. End-to-end behavior is correct (the MLP's first layer absorbs the discrepancy), but the next reader to compare our code against sklearn would be confused.

Comment block added at all four sites — `inference.rs`, `train_hybrid.py`, `train_distill.py`, `train_distill_reduced.py` — with a "do not 'fix' the direction in isolation; every shipped v1.x / v2.x bake depends on this convention" warning.

## (2) Canonical end-to-end command sequence

`zenpicker/tools/README.md`'s old `## End-to-end` section was 4 stages and predated the safety / ablation / probe / diagnose work that landed across PRs #34 / #35 / #36. Replaced with a 6-stage canonical sequence + per-flag reference table:

  1. Sweep (codec harness, with `--features-only` re-extract path)
  2. Train (`train_hybrid.py --codec-config <…> --objective {size_optimal, zensim_strict} --hidden W,W,W`, auto-strict via CI=1)
  3. Permutation-importance ablation (auto-strict)
  4. Bake (refuses unsafe JSONs absent `--allow-unsafe`)
  5. Roundtrip check
  6. Adversarial probe + diagnose

Every codec bake from now on (including the upcoming cross-codec bake) runs this same 6-stage pipeline. Future codec bring-ups copy the section verbatim and substitute their codec name.