### PR TITLE
feat(zenpicker): size invariance — structural discipline + probe + safety gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — zenpicker size-invariance discipline
+
+- **Size invariance is a safety property.** The picker is now
+  *required* to be near-optimal at every image `(width, height)`, not
+  just at the four sample sizes (`tiny / small / medium / large`)
+  sampled at training time. This is now structural, not a "be
+  thorough" guideline.
+- **`tools/train_hybrid.py`: new safety-gate violations.** Two new
+  thresholds in `DEFAULT_SAFETY_THRESHOLDS`:
+  - `max_per_size_p99_overhead_pct` (default 80) — `PER_SIZE_TAIL`
+    fires when any single `size_class`'s p99 overhead exceeds the
+    ceiling.
+  - `min_train_rows_per_size_zq` (default 50) — `DATA_STARVED_SIZE`
+    fires when any `(size_class, target_zq)` training cell has fewer
+    rows than the floor. Catches sweep harnesses that silently skip a
+    size class for a chunk of the corpus.
+- **`safety_report.diagnostics.train_rows_by_size_zq`**: new dict in
+  the diagnostics block exposing per-`(size, zq)` training-row counts.
+  Forwarded into the bake manifest by `bake_picker.py` (passes through
+  the existing `safety_report` plumbing — no bake-tool change needed).
+- **`zenpicker/tools/size_invariance_probe.py`** — post-bake
+  generalization gate. Resizes a fixture corpus to each of `tiny /
+  small / medium / large` and asserts the picker's argmin cell stays
+  stable across sizes per `(image, target_zq)`. `--strict` exits 1
+  when stability < threshold (default 90 %). Counterpart to the
+  in-trainer `PER_SIZE_TAIL` / `DATA_STARVED_SIZE` violations.
+- **Documentation updates.** `SAFETY_PLANE.md` gains a "Size
+  invariance is a safety property" section; `FOR_NEW_CODECS.md` gains
+  Step 1.5 ("sweep at all four size classes") between Steps 1 and 2;
+  `tools/README.md` extends the canonical command sequence with the
+  size-invariance probe; `README.md` marks the size-invariance gate
+  ✅ v0.1; `lib.rs` docstring documents that size invariance is
+  enforced at the codec edge, not in the picker runtime.
+
 ### Changed — zenpicker
 
 - **`tools/train_hybrid.py`: codec-agnostic `CATEGORICAL_AXES` + `SCALAR_AXES`.**

--- a/zenpicker/FOR_NEW_CODECS.md
+++ b/zenpicker/FOR_NEW_CODECS.md
@@ -40,6 +40,48 @@ For zenjpeg this is `zenjpeg/examples/zq_pareto_calibrate.rs`. Yours can be a on
 
 ---
 
+## Step 1.5 — sweep at all four size classes (size invariance is a safety property)
+
+The codec's pareto sweep harness MUST emit rows for `tiny / small / medium / large` for **every image** in the corpus, not just one size per image. Sparse-by-size sweeps silently produce mis-calibrated pickers — the safety plane treats this as a first-class concern, not a "be thorough" guideline.
+
+**Why this is non-negotiable:**
+
+The picker is feature-vector-in / argmin-out. It has no notion of image dimensions at runtime — only the `size_class` one-hot and `log_pixels` cross-terms the codec packs into the feature vector. A picker that was trained without enough samples in (e.g.) the `tiny` × `zq=94` corner has nothing to learn from there; at inference it extrapolates and the codec gets a bad pick at exactly the (size, quality) pair where SLA-bound traffic lives.
+
+`train_hybrid.py` enforces this with two strict-gate violations:
+
+- **`PER_SIZE_TAIL`** — fails when any single `size_class`'s p99 overhead exceeds `max_per_size_p99_overhead_pct` (default 80 %).
+- **`DATA_STARVED_SIZE`** — fails when any `(size_class, target_zq)` cell has fewer than `min_train_rows_per_size_zq` (default 50) training rows.
+
+**Reference implementation:** zenjpeg's harness loops over all four size classes per image, producing one feature row + one `(image, size, config, q)` pareto row per size:
+
+```rust
+// zenjpeg/zenjpeg/examples/zq_pareto_calibrate.rs:506-512
+let work_units: Vec<(PathBuf, u32)> = paths
+    .iter()
+    .flat_map(|path| args.sizes.iter().map(move |&sz| (path.clone(), sz)))
+    .collect();
+work_units.par_iter().for_each(|(path, target_size)| {
+    let target_size = *target_size;
+    let (rgb_native, w_native, h_native) = load_png(path);
+    let (rgb, w, h) = resize_to(&rgb_native, w_native, h_native, target_size);
+    let size_class = match target_size {
+        64 => "tiny",
+        256 => "small",
+        1024 => "medium",
+        0 => "large",     // native — no resize
+        _ => "custom",
+    };
+    // ... analyze + encode + emit rows ...
+});
+```
+
+The default `--sizes 64,256,1024,0` covers `(tiny, small, medium, large)` per image. Don't override that grid unless you genuinely have a domain reason (e.g. a thumbnail-only product where `medium` and `large` are out-of-scope) — and if you do, document it in the codec config and tighten `min_train_rows_per_size_zq` accordingly.
+
+**Post-bake gate.** Once the `.bin` ships, `tools/size_invariance_probe.py` resizes a fixture corpus through the picker at all four sizes and asserts the argmin cell stays stable across them per `(image, target_zq)`. Run it as part of CI alongside `adversarial_probe.py`. See [tools/README.md](tools/README.md) → step 6c.
+
+---
+
 ## Step 2 — produce a features TSV
 
 One row per `(image, size_class)`, columns prefixed `feat_`:
@@ -344,6 +386,8 @@ The gate catches (full list in [tools/README.md → Safety gates](tools/README.m
 
 - overfitting (train/val gap > threshold)
 - catastrophic per-zq-band tails (p99 overhead exceeds threshold for any single band — caught a real 85.4% miss at zq=94 in zenjpeg's own v2.1)
+- catastrophic per-size-class tails (`PER_SIZE_TAIL`: p99 overhead exceeds `max_per_size_p99_overhead_pct` for any single `size_class`. Size invariance is a safety property — see Step 1.5)
+- size-starved sweep grids (`DATA_STARVED_SIZE`: fewer than `min_train_rows_per_size_zq` training rows in any `(size_class, target_zq)` cell)
 - single-row worst-case overshoot (>200% by default)
 - data-starved cells (fewer than 3 member configs)
 - NaN/Inf in weights or predictions

--- a/zenpicker/README.md
+++ b/zenpicker/README.md
@@ -478,6 +478,7 @@ Memory: 30 KB (f16) or 60 KB (f32) embedded; one prediction call allocates nothi
 | ✅ v0.1 | **v2.1 zenjpeg bake** (35-feature schema, 192³ MLP) — adds `patch_fraction_fast`, `quant_survival_y/uv`, `aq_map_*`, `laplacian_variance`, etc. Beats v2.0 by 0.43pp mean overhead, +4.3pp argmin acc |
 | ✅ v0.1 | **Permutation feature importance** (`feature_ablation.py --method permutation`) — train once, shuffle each column. ~50× faster than retrain-LOO (2 min vs 1-2 hr at 53 features × 120 configs) |
 | ✅ v0.1 | **`--hidden W,W,W` capacity sweep** in `train_hybrid.py` — depth helps more than width past ~50-input cross-termed MLPs; 192³ overtakes the 128² default cleanly |
+| ✅ v0.1 | **Size-invariance gate** — `train_hybrid.py` ships `PER_SIZE_TAIL` + `DATA_STARVED_SIZE` strict-gate violations and `safety_report.diagnostics.train_rows_by_size_zq`; `tools/size_invariance_probe.py` is the post-bake stability check. The picker is *required* to be near-optimal at every `(width, height)`, not just at the four sample sizes — see [SAFETY_PLANE.md → "Size invariance is a safety property"](SAFETY_PLANE.md#size-invariance-is-a-safety-property) |
 | ⏳ v0.2 | `#[magetypes]`-dispatched matmul (AVX-512 / AVX2 / NEON / WASM SIMD128 / scalar). 8-wide f16 → f32 via F16C / FCVT |
 | ⏳ v0.3 | i8-quantized weights option (per-row scale) for the case where ~50 KB still isn't small enough |
 | ⏳ v0.3 | Generational re-encode picker (round-trip JPEG-source case): see [imazen/zenanalyze#13](https://github.com/imazen/zenanalyze/issues/13) |

--- a/zenpicker/SAFETY_PLANE.md
+++ b/zenpicker/SAFETY_PLANE.md
@@ -2,6 +2,20 @@
 
 Defends against the picker's worst-case failure mode: an out-of-distribution or adversarial image where the MLP confidently picks a config that produces zensim *catastrophically below* the user's `target_zq`. A 5–15% byte overage is acceptable; a 30-point quality miss is a product failure.
 
+## Size invariance is a safety property
+
+The picker MUST be near-optimal at every image `(width, height)` — not just at the four sample sizes (`tiny / small / medium / large`) we bin at training time. `size_class` is a *training-grid axis*, not a runtime axis: the codec resizes user images to whatever pixel count the caller requests, and the picker has to translate any of those into a sensible config. A picker whose argmin cell *flips drastically* when the same image is fed at a different size is encoding size as a categorical decision boundary instead of a smooth interpolation — which means at sizes the training grid didn't sample (e.g. 512×512 between `small=256²` and `medium=1024²`), the pick is whichever side of the boundary the cross-term landed on, and the codec has no idea.
+
+Treat this as a safety property on the same footing as out-of-distribution detection and the verify/rescue path:
+
+1. **In-trainer gate.** `train_hybrid.py` emits `safety_report.diagnostics.by_size` (mean / p99 / max overhead per `size_class`) and `safety_report.diagnostics.train_rows_by_size_zq` (training-row counts per `(size_class, target_zq)` cell). The strict gate fires `PER_SIZE_TAIL` when any single size's p99 exceeds `max_per_size_p99_overhead_pct` (default 80 %) and `DATA_STARVED_SIZE` when any `(size_class, zq)` cell has fewer than `min_train_rows_per_size_zq` (default 50) training rows. Both are structural — the codec's pareto sweep MUST emit rows at all four size classes per image (see `FOR_NEW_CODECS.md` Step 1.5).
+
+2. **Post-bake gate.** `tools/size_invariance_probe.py` resizes a fixture corpus (sampled from `~/work/codec-eval/codec-corpus/`) to each of `(64×64, 256×256, 1024×1024, native)` and asserts that the picker's argmin cell stays stable across the four sizes for each `(image, target_zq)` pair. `--strict` exits 1 when stability drops below `--threshold` (default 90 %). This is the picker's *generalization* test — analogous to `adversarial_probe.py` for out-of-distribution inputs.
+
+3. **Why this matters more than the global mean.** The `by_size` block on the v2.1 bake shows tiny p99 = 41.7 % vs medium = 18.1 % — the global mean overhead (1.92 %) hides a tail that lives almost entirely on small images. SLA-bound deployments that serve thumbnails see the worst of the picker's failure modes; the safety gate fires before the bake ships, not after.
+
+The picker itself stays codec-agnostic — `zenpicker` has no notion of width/height. The discipline lives in the training pipeline (the strict gate) and the bake-side probe (the post-bake check). What the runtime crate guarantees is that *whatever feature vector the codec hands it, including the `size_class` one-hot and `log_pixels` cross-terms, gets a deterministic forward pass*. The size-invariance guarantees come from the gates around that.
+
 ## Existing scaffolding (what we already have)
 
 - `zenjpeg/src/encode/zq.rs` defines a closed-loop `ZqTarget { max_passes, max_undershoot, BlockArtifactBound }` and a public `EncodeMetrics { achieved_score, achieved_max_block_artifact, passes_used, bytes, targets_met }`. `BytesEncoder::finish_with_metrics()` returns it (`encode/byte_encoders.rs:543`).

--- a/zenpicker/src/lib.rs
+++ b/zenpicker/src/lib.rs
@@ -37,6 +37,37 @@
 //! at ~no accuracy cost; SIMD f16→f32 (F16C / FCVT) is the v0.2
 //! work, scalar today.
 //!
+//! ## Size invariance is a codec-edge concern
+//!
+//! `zenpicker` is feature-vector-in / argmin-out. It has no notion of
+//! image dimensions at runtime — the picker doesn't know whether the
+//! caller's image is 64×64 or 4096×4096 except through whatever the
+//! codec packs into the feature vector (`size_class` one-hot,
+//! `log_pixels`, etc., all defined by the codec's bake schema).
+//!
+//! That means **size invariance is enforced at the codec edge**, not
+//! here. The picker faithfully runs whatever forward pass the bake
+//! encoded; if the training-time `(size_class, target_zq)` grid was
+//! sparsely populated, the picker will silently extrapolate at
+//! inference and the codec will get bad picks for those (size,
+//! quality) corners.
+//!
+//! Two structural gates protect against this and they live outside
+//! this crate (in the training/bake pipeline):
+//!
+//! 1. `train_hybrid.py`'s `PER_SIZE_TAIL` + `DATA_STARVED_SIZE`
+//!    safety violations — fail the strict gate when any size class's
+//!    p99 overhead is too high or when any `(size_class, zq)` cell
+//!    has fewer training rows than the floor.
+//! 2. `tools/size_invariance_probe.py` — post-bake stability check
+//!    that resizes a fixture corpus to each of {tiny, small, medium,
+//!    large} and asserts the picker's argmin cell stays stable.
+//!
+//! See [`SAFETY_PLANE.md`](https://github.com/imazen/zenanalyze/blob/main/zenpicker/SAFETY_PLANE.md)
+//! → "Size invariance is a safety property" for the design notes and
+//! [`FOR_NEW_CODECS.md`](https://github.com/imazen/zenanalyze/blob/main/zenpicker/FOR_NEW_CODECS.md)
+//! → Step 1.5 for the codec-side sweep discipline.
+//!
 //! ## no_std
 //!
 //! `default-features = false` keeps the crate `no_std + alloc`. The

--- a/zenpicker/tools/README.md
+++ b/zenpicker/tools/README.md
@@ -18,6 +18,7 @@ config-name parser. Then runs these scripts against that config.
 | `validate_schema.py` | Re-train production HistGB with a chosen feature subset, report held-out metrics |
 | `capacity_sweep.py` | Architecture × cross-term-recipe sweep over the student MLP |
 | `adversarial_probe.py` | Corner-case spot-check for any model JSON: zeros / huge / NaN / Inf / single-feature spike. Asserts no NaN/Inf in output, top-1/top-2 gap ≥ 0, predicted bytes plausible. Exits 1 in `--strict` |
+| `size_invariance_probe.py` | Post-bake size-generalization gate. Resizes fixture images to each of `tiny / small / medium / large` and asserts the picker's argmin cell stays stable across them per `(image, target_zq)`. Counterpart to `train_hybrid.py`'s `PER_SIZE_TAIL` / `DATA_STARVED_SIZE` violations. Exits 1 in `--strict` when stability < threshold (default 90 %). See [SAFETY_PLANE.md](../SAFETY_PLANE.md#size-invariance-is-a-safety-property) |
 | `diagnose_picker.py` | Human-readable health report for any model JSON or .manifest.json. Works on legacy bakes that pre-date `safety_report` (falls back to a static MLP weight scan) |
 
 The [`tools/bake_picker.py`](../../tools/bake_picker.py) script (parent
@@ -101,7 +102,15 @@ python3 <zenanalyze>/tools/bake_roundtrip_check.py \
 #    a) Adversarial probe: zeros / huge / NaN / Inf / single-feature spike.
 python3 <zenanalyze>/zenpicker/tools/adversarial_probe.py --strict \
     --model benchmarks/<bake-base>.json
-#    b) Human-readable health report — review by eye.
+#    b) Size-invariance probe: resize fixture images to all four
+#       size_classes and assert the picker's argmin stays stable.
+#       The post-bake counterpart to train_hybrid.py's PER_SIZE_TAIL
+#       + DATA_STARVED_SIZE violations. See SAFETY_PLANE.md →
+#       "Size invariance is a safety property".
+python3 <zenanalyze>/zenpicker/tools/size_invariance_probe.py --strict \
+    --model        benchmarks/<bake-base>.json \
+    --features-tsv benchmarks/<features>.tsv
+#    c) Human-readable health report — review by eye.
 python3 <zenanalyze>/zenpicker/tools/diagnose_picker.py \
     --model benchmarks/<bake-base>.json
 ```
@@ -204,6 +213,8 @@ is enough at our 7000-row scale.
 | `LOW_ARGMIN` | val argmin accuracy below floor (default 30%) |
 | `HIGH_OVERHEAD` | val mean overhead exceeds ceiling (default 10%) |
 | `PER_ZQ_TAIL` | any single target_zq band's p99 overhead exceeds threshold (default 80%) — catches catastrophic misses concentrated in one quality band |
+| `PER_SIZE_TAIL` | any single `size_class`'s p99 overhead exceeds `max_per_size_p99_overhead_pct` (default 80%). Size invariance is a safety property — see [SAFETY_PLANE.md](../SAFETY_PLANE.md#size-invariance-is-a-safety-property) |
+| `DATA_STARVED_SIZE` | any `(size_class, target_zq)` cell has fewer than `min_train_rows_per_size_zq` training rows (default 50). Catches sweep harnesses that silently skip a size class |
 | `WORST_ROW` | any single (image, size, zq) row exceeds threshold (default 200%) |
 | `DATA_STARVED_CELL` | any cell has fewer member configs than threshold (default 3) |
 | `NAN_WEIGHTS` / `INF_WEIGHTS` / `NAN_PREDICTIONS` | NaN or Inf in MLP weights or val predictions |
@@ -242,6 +253,8 @@ Codec runtime emits a compile-time `FEATURE_BOUNDS: &[zenpicker::FeatureBounds]`
 ### Adversarial probe + diagnose (post-bake spot-check)
 
 `adversarial_probe.py --model <bake>.json --strict` runs ~10 corner inputs (zeros, huge, NaN, Inf, single-feature spike) and asserts no NaN/Inf in output, top-1/top-2 gap ≥ 0, predicted bytes plausible. Cheap CI gate after `bake_picker.py`.
+
+`size_invariance_probe.py --model <bake>.json --features-tsv <features>.tsv --strict` runs the picker against ~10 fixture images at all four `size_class` resizes and asserts the argmin cell stays stable across them per `(image, target_zq)`. The post-bake counterpart to `train_hybrid.py`'s `PER_SIZE_TAIL` / `DATA_STARVED_SIZE` violations — see [SAFETY_PLANE.md → "Size invariance is a safety property"](../SAFETY_PLANE.md#size-invariance-is-a-safety-property) for the rationale.
 
 `diagnose_picker.py --model <bake>.json` (or `--manifest <bake>.manifest.json`) prints a human-readable health report. Useful for reviewing a bake by eye. Falls back gracefully on legacy bakes (pre-`safety_report`) by computing a static MLP weight scan from the JSON layers.
 

--- a/zenpicker/tools/size_invariance_probe.py
+++ b/zenpicker/tools/size_invariance_probe.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""
+Size-invariance probe for a baked picker JSON.
+
+Size invariance is a *safety property* of the picker (see
+SAFETY_PLANE.md → "Size invariance is a safety property"). The picker
+is a feature-vector-in / argmin-out function — it has no notion of
+image dimensions at runtime, only what the codec packs into the
+feature vector via `size_class` one-hot, `log_pixels`, and the
+zq×feature cross-terms. The picker MUST produce trustworthy picks at
+every (width, height), not just at the four sample sizes
+{tiny, small, medium, large} we sampled at training time.
+
+This probe answers: given the same image content at four sizes, does
+the picker's argmin cell stay stable across `size_class`? At each
+`target_zq`? A stable argmin across all four sizes for a given image
+is the canonical "size invariant" outcome — the codec is making the
+*same encoder-config decision* regardless of resize. If the cell
+flips drastically when an image is resized, the picker's pick at
+that (image, zq) is sensitive to size in a way the safety plane
+needs to know about.
+
+# Inputs
+
+This script consumes a features TSV produced by the codec's pareto
+sweep harness — same shape `train_hybrid.py` reads:
+
+    image_path<TAB>size_class<TAB>width<TAB>height<TAB>feat_<col>...
+
+The harness must have run with `--features-only` over a corpus that
+covers all four size_classes per image. For zenjpeg that's:
+
+    cargo run --release -p zenjpeg --features 'target-zq trellis' \\
+        --example zq_pareto_calibrate -- --features-only \\
+        --corpus /home/lilith/work/codec-eval/codec-corpus/...
+
+(See FOR_NEW_CODECS.md Step 1.5 for the codec-side discipline that
+makes this TSV exist.)
+
+By default the probe samples ~10 images that cover all four sizes;
+override with `--n-images` and `--seed`. For each image it builds
+the same feature vector `train_hybrid.py` builds (raw feats +
+size_oh + log_px + zq cross-terms + icc placeholder) and runs the
+forward pass via the Python numpy reference (no Rust dependency).
+
+# Stability metric
+
+For each image i and target_zq z:
+    cells_i_z = {argmin_cell(i, sz, z) for sz in
+                  {tiny, small, medium, large}}
+    stable_i_z = (|cells_i_z| == 1)
+
+Image-level stability:
+    stable_i = mean over z of stable_i_z
+
+Corpus-level stability:
+    stability_pct = 100 * mean over (i, z) of stable_i_z
+
+`--strict` exits 1 when `stability_pct < --threshold` (default 90.0).
+This is the post-bake gate counterpart to `train_hybrid.py`'s
+in-trainer `PER_SIZE_TAIL` and `DATA_STARVED_SIZE` violations.
+
+# Why this matters
+
+A picker that flips its cell pick when the same image is fed at a
+different size is making encoder-config decisions on signal that
+*should* be size-invariant. The right response is one of:
+  1. Retrain with denser per-size coverage (DATA_STARVED_SIZE gate)
+  2. Re-engineer the cross-term layout so size enters more
+     gracefully into the feature vector
+  3. Accept that some content (e.g. tiny screen captures) genuinely
+     wants a different config than the same content at 4K — but
+     surface the rate so it's not silently the picker's failure mode
+
+# Usage
+
+    python3 size_invariance_probe.py \\
+        --model benchmarks/zq_bytes_hybrid_v2_1.json \\
+        --features-tsv benchmarks/zq_pareto_features_2026-04-29_v2_1.tsv \\
+        [--n-images 10] [--threshold 90.0] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import random
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+
+
+def relu_forward(x: np.ndarray, layers: list[dict]) -> np.ndarray:
+    """ReLU MLP forward pass — final layer identity. Matches
+    train_hybrid.py / adversarial_probe.py."""
+    a = x
+    last = len(layers) - 1
+    for i, layer in enumerate(layers):
+        W = np.asarray(layer["W"], dtype=np.float64)
+        b = np.asarray(layer["b"], dtype=np.float64)
+        z = a @ W + b
+        a = z if i == last else np.maximum(z, 0.0)
+    return a
+
+
+def standardize(x: np.ndarray, mean: np.ndarray, scale: np.ndarray) -> np.ndarray:
+    safe_scale = np.where(scale == 0.0, 1.0, scale)
+    return (x - mean) / safe_scale
+
+
+def build_engineered_input(
+    raw_feats: np.ndarray,
+    size_class: str,
+    width: int,
+    height: int,
+    zq: int,
+) -> np.ndarray:
+    """Reproduces train_hybrid.py's `xe` construction.
+
+    Layout (must match `build_dataset` in train_hybrid.py):
+        f                              (n_feat,)
+        size_oh                        (4,)
+        [log_px, log_px², zq_norm,
+         zq_norm², zq_norm × log_px]   (5,)
+        zq_norm × f                    (n_feat,)
+        [icc_bytes_placeholder]        (1,)
+    """
+    log_px = math.log(max(1, width * height))
+    zq_norm = zq / 100.0
+    size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float64)
+    size_oh[SIZE_INDEX[size_class]] = 1.0
+    return np.concatenate([
+        raw_feats.astype(np.float64),
+        size_oh,
+        np.array([log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px]),
+        zq_norm * raw_feats.astype(np.float64),
+        np.array([0.0]),
+    ])
+
+
+def load_features_tsv(path: Path, feat_cols: list[str]):
+    """Load features TSV indexed by (image_path, size_class).
+
+    Returns: {(image, size): {"feats": ndarray, "w": int, "h": int}}
+    """
+    out = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        all_cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        # Order MUST match the bake's feat_cols (the picker's first
+        # n_feat inputs are positionally defined).
+        missing = [c for c in feat_cols if c not in all_cols]
+        if missing:
+            raise SystemExit(
+                f"features TSV is missing {len(missing)} columns the bake "
+                f"declares: {missing[:5]}{'...' if len(missing) > 5 else ''}"
+            )
+        for r in rdr:
+            key = (r["image_path"], r["size_class"])
+            try:
+                w = int(r["width"])
+                h = int(r["height"])
+                feats = np.array([float(r[c]) for c in feat_cols], dtype=np.float64)
+            except (ValueError, KeyError):
+                continue
+            out[key] = {"feats": feats, "w": w, "h": h}
+    return out
+
+
+def pick_argmin(model: dict, feat_vec: np.ndarray, n_cells: int) -> int:
+    """Run the forward pass and return the argmin cell index over the
+    bytes-log subrange. No reach mask — we want the picker's *raw*
+    pick, identical to what the codec runtime would compute before
+    the constraint mask is applied."""
+    mean = np.asarray(model["scaler_mean"], dtype=np.float64)
+    scale = np.asarray(model["scaler_scale"], dtype=np.float64)
+    x = standardize(feat_vec, mean, scale).reshape(1, -1)
+    out = relu_forward(x, model["layers"]).ravel()
+    bytes_log = out[:n_cells]
+    return int(np.argmin(bytes_log))
+
+
+def select_fixture_images(
+    feats_by_key: dict, n_images: int, seed: int
+) -> list[str]:
+    """Pick images that have features at all four size_classes.
+    Sampling without replacement, deterministic for `seed`."""
+    by_image = defaultdict(set)
+    for (img, sz), _ in feats_by_key.items():
+        by_image[img].add(sz)
+    full = sorted(
+        img for img, szs in by_image.items()
+        if all(s in szs for s in SIZE_CLASSES)
+    )
+    if not full:
+        raise SystemExit(
+            "no images in features TSV cover all four size_classes — "
+            "the codec's pareto sweep harness must run at "
+            "tiny / small / medium / large per image. See "
+            "FOR_NEW_CODECS.md Step 1.5."
+        )
+    rng = random.Random(seed)
+    rng.shuffle(full)
+    return full[:n_images]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, type=Path,
+                    help="trained model JSON (output of train_hybrid.py)")
+    ap.add_argument("--features-tsv", required=True, type=Path,
+                    help="features TSV (output of codec's --features-only "
+                    "sweep harness; must cover all four size_classes per image)")
+    ap.add_argument("--n-images", type=int, default=10,
+                    help="number of fixture images to probe (default 10)")
+    ap.add_argument("--seed", type=int, default=0xC0FFEE,
+                    help="seed for fixture sampling (default 0xC0FFEE)")
+    ap.add_argument("--zq-targets", type=str, default=None,
+                    help="comma-separated target_zq values to probe. "
+                    "Default: read from model JSON's training_objective "
+                    "or the canonical zenjpeg grid 0..70 step 5 + 70..100 step 2")
+    ap.add_argument("--threshold", type=float, default=90.0,
+                    help="stability percentage floor for --strict (default 90.0)")
+    ap.add_argument("--strict", action="store_true",
+                    help="Auto-enabled in CI. Exit code 1 when "
+                    "stability_pct < threshold.")
+    args = ap.parse_args()
+
+    model = json.loads(args.model.read_text())
+    feat_cols = model.get("feat_cols")
+    if not feat_cols:
+        raise SystemExit("model JSON has no feat_cols — re-bake with current trainer")
+    n_cells = (
+        model.get("hybrid_heads_manifest", {}).get("n_cells")
+        or int(model.get("n_outputs", 0))
+    )
+    if not n_cells:
+        raise SystemExit("model JSON has no n_cells / n_outputs")
+
+    if args.zq_targets:
+        zq_targets = [int(z) for z in args.zq_targets.split(",")]
+    else:
+        zq_targets = list(range(0, 70, 5)) + list(range(70, 101, 2))
+
+    sys.stderr.write(
+        f"size_invariance_probe: model={args.model} n_cells={n_cells} "
+        f"feat_cols={len(feat_cols)} zq_targets={len(zq_targets)}\n"
+    )
+
+    feats = load_features_tsv(args.features_tsv, feat_cols)
+    images = select_fixture_images(feats, args.n_images, args.seed)
+    sys.stderr.write(
+        f"  loaded {len(feats)} (image, size) feature rows; "
+        f"sampled {len(images)} fixtures covering all 4 sizes\n\n"
+    )
+
+    # Per-(image, zq), gather the 4 picks (one per size_class).
+    n_pairs = 0
+    n_stable = 0
+    per_image = {}  # img -> stability fraction
+    flips = []  # (img, zq, picks_per_size) for the worst flips
+    for img in images:
+        per_image[img] = {"stable": 0, "n": 0, "by_zq": {}}
+        for zq in zq_targets:
+            picks = []
+            for sz in SIZE_CLASSES:
+                row = feats.get((img, sz))
+                if row is None:
+                    picks.append(None)
+                    continue
+                xe = build_engineered_input(
+                    row["feats"], sz, row["w"], row["h"], zq
+                )
+                picks.append(pick_argmin(model, xe, n_cells))
+            if any(p is None for p in picks):
+                continue
+            unique = set(picks)
+            stable = len(unique) == 1
+            n_pairs += 1
+            n_stable += int(stable)
+            per_image[img]["n"] += 1
+            per_image[img]["stable"] += int(stable)
+            per_image[img]["by_zq"][zq] = picks
+            if not stable:
+                flips.append((img, zq, picks, len(unique)))
+
+    if n_pairs == 0:
+        sys.stderr.write(
+            "no (image, zq) pairs produced picks at all 4 sizes — "
+            "check that the features TSV covers tiny/small/medium/large "
+            "for the sampled images.\n"
+        )
+        return 1 if args.strict else 0
+
+    stability_pct = 100.0 * n_stable / n_pairs
+
+    # Per-image table.
+    sys.stderr.write(
+        f"{'image':<60s}  {'stable/n':>10s}  pct\n"
+    )
+    for img in images:
+        rec = per_image[img]
+        if rec["n"] == 0:
+            sys.stderr.write(f"  {img:<58s}  {'(skipped)':>10s}  --\n")
+            continue
+        pct = 100.0 * rec["stable"] / rec["n"]
+        sys.stderr.write(
+            f"  {img:<58s}  {rec['stable']:>4d}/{rec['n']:<4d}   {pct:5.1f}%\n"
+        )
+
+    sys.stderr.write(
+        f"\nCorpus stability: {n_stable}/{n_pairs} = {stability_pct:.2f}% "
+        f"(threshold {args.threshold:.1f}%)\n"
+    )
+
+    # Top flips (worst non-stable cases by cell-count diversity).
+    if flips:
+        flips.sort(key=lambda f: -f[3])
+        sys.stderr.write("\nTop flips (most cells visited across sizes):\n")
+        for img, zq, picks, k in flips[:6]:
+            picks_str = ", ".join(
+                f"{sz}={p}" for sz, p in zip(SIZE_CLASSES, picks)
+            )
+            sys.stderr.write(
+                f"  {img}  @zq{zq}  {k} distinct cells: {picks_str}\n"
+            )
+
+    failed = stability_pct < args.threshold
+    if failed:
+        sys.stderr.write(
+            f"\n[FAIL] stability {stability_pct:.2f}% < threshold {args.threshold:.1f}%\n"
+        )
+    else:
+        sys.stderr.write(
+            f"\n[OK] stability {stability_pct:.2f}% >= threshold {args.threshold:.1f}%\n"
+        )
+
+    return 1 if (failed and args.strict) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zenpicker/tools/train_hybrid.py
+++ b/zenpicker/tools/train_hybrid.py
@@ -489,6 +489,22 @@ DEFAULT_SAFETY_THRESHOLDS = dict(
     max_mean_overhead_pct=10.0,
     # No single zq band may have a p99 overhead this bad.
     max_per_zq_p99_overhead_pct=80.0,
+    # No single image-size class may have a p99 overhead this bad.
+    # Size invariance is a *safety property*: the picker must be
+    # near-optimal at every (width, height), not just on average.
+    # Tiny images (≤64×64) historically tail worst — tight per-bin
+    # gates catch a tiny-class blowup that the global mean would
+    # absorb. See SAFETY_PLANE.md → "Size invariance is a safety
+    # property" and the size_invariance_probe.py post-bake gate.
+    max_per_size_p99_overhead_pct=80.0,
+    # Each (size_class, target_zq) training cell must have at least
+    # this many rows. Below this, the teacher fits noise in a
+    # corner of the size×quality grid the picker still has to serve
+    # at inference. The codec's pareto sweep MUST emit rows for
+    # tiny / small / medium / large per image (see
+    # FOR_NEW_CODECS.md Step 1.5); this gate fires when the sweep
+    # silently skips a size class for a chunk of the corpus.
+    min_train_rows_per_size_zq=50,
     # No single (image, size, zq) row may overshoot by more than
     # this. Catches catastrophic individual failures.
     max_single_row_overhead_pct=200.0,
@@ -551,6 +567,28 @@ def compute_feature_bounds(feats, train_keys, feat_cols):
             "std": float(v_finite.std()),
             "n": int(v_finite.size),
         }
+    return out
+
+
+def count_train_rows_by_size_zq(meta_tr, size_classes, zq_targets):
+    """Count training rows per (size_class, zq) cell.
+
+    Size invariance discipline (see SAFETY_PLANE.md): the picker is a
+    feature-vector-in / argmin-out function — it has no notion of
+    image dimensions at runtime, so the codec must populate every
+    (size_class, target_zq) cell with enough training data for the
+    teacher to learn from. A sparsely-sampled cell silently trains
+    noise into a corner of the size × quality grid the picker still
+    has to serve at inference. This counter feeds the
+    `DATA_STARVED_SIZE` safety violation.
+
+    Returns: {size_class: {zq: int}} with every declared
+    `size_classes × zq_targets` combination present (zero when the
+    sweep emitted no rows for that cell)."""
+    out = {sz: {int(zq): 0 for zq in zq_targets} for sz in size_classes}
+    for _img, sz, zq in meta_tr:
+        if sz in out and int(zq) in out[sz]:
+            out[sz][int(zq)] += 1
     return out
 
 
@@ -728,6 +766,45 @@ def safety_check(diag, thresholds, objective: str):
                 f"PER_ZQ_TAIL: zq={zq} p99 overhead {m['p99_pct']:.1f}% "
                 f"> threshold {thresholds['max_per_zq_p99_overhead_pct']:.1f}%"
             )
+
+    # Size invariance: the picker must be near-optimal at every
+    # image (width, height), not just on the global average. Tiny
+    # images historically tail worst (small absolute headers
+    # dominate per-pixel cost) — a per-size p99 ceiling is the
+    # in-trainer counterpart to size_invariance_probe.py's
+    # post-bake stability check.
+    for sz, m in diag.get("by_size", {}).items():
+        if m["p99_pct"] > thresholds["max_per_size_p99_overhead_pct"]:
+            v.append(
+                f"PER_SIZE_TAIL: size_class={sz} p99 overhead {m['p99_pct']:.1f}% "
+                f"> threshold {thresholds['max_per_size_p99_overhead_pct']:.1f}% "
+                f"(picker is not size-invariant — see SAFETY_PLANE.md)"
+            )
+
+    # Data-starvation gate per (size_class, target_zq) training
+    # cell. Catches sweep harnesses that silently skip a size
+    # class for a chunk of the corpus, leaving the picker with
+    # too few examples to learn from at that (size, quality)
+    # corner. Codec's harness MUST emit rows for tiny / small /
+    # medium / large per image (FOR_NEW_CODECS.md Step 1.5).
+    starved = []
+    for sz, by_zq in diag.get("train_rows_by_size_zq", {}).items():
+        for zq, n in by_zq.items():
+            if n < thresholds["min_train_rows_per_size_zq"]:
+                starved.append((sz, zq, n))
+    if starved:
+        # Surface the worst (lowest-n) cells; capping at 6 lines
+        # keeps the log readable when a whole size class is missing.
+        starved.sort(key=lambda t: t[2])
+        examples = ", ".join(
+            f"{sz}/zq{zq}={n}" for (sz, zq, n) in starved[:6]
+        )
+        more = f" (+{len(starved) - 6} more)" if len(starved) > 6 else ""
+        v.append(
+            f"DATA_STARVED_SIZE: {len(starved)} (size_class, zq) cell(s) "
+            f"have train rows < {thresholds['min_train_rows_per_size_zq']}: "
+            f"{examples}{more}"
+        )
 
     if diag["worst_case"]:
         worst = diag["worst_case"][0]
@@ -1150,12 +1227,21 @@ def main():
         bl_tr, rch_tr, meta_tr, n_cells, ZQ_TARGETS, args.reach_threshold
     )
 
+    # Size-invariance discipline: count training rows per
+    # (size_class, zq) so the safety gate can flag a starved sweep
+    # corner before the picker ships a model that can't actually
+    # serve every (width, height) the codec is asked to encode.
+    train_rows_by_size_zq = count_train_rows_by_size_zq(
+        meta_tr, SIZE_CLASSES, ZQ_TARGETS
+    )
+
     # --- Safety report: assemble + check thresholds
     diag = {
         "argmin": {"train": student_argmin_tr, "val": student_argmin},
         "by_zq": by_zq,
         "by_size": by_size,
         "by_zq_size": by_zq_size,
+        "train_rows_by_size_zq": train_rows_by_size_zq,
         "worst_case": worst,
         "per_cell": per_cell,
         "mlp": mlp_health,


### PR DESCRIPTION
## Summary

Treat size invariance as a first-class safety property: the picker MUST be near-optimal at every image `(width, height)`, not just at the four sample sizes (`tiny / small / medium / large`) sampled at training time. Today the discipline is implicit (`size_class` is one input axis, `safety_report.by_size` happens to break down by size); this PR makes it impossible to miss for the next codec author and impossible to regress in CI.

## Deliverables (mapped to the prompt)

### 1. Audit + tighten the existing size axis

- **train_hybrid.py**: two new strict-gate violations and a new diagnostics block.
  - `PER_SIZE_TAIL` — fires when any single `size_class`'s p99 overhead exceeds `max_per_size_p99_overhead_pct` (default 80).
  - `DATA_STARVED_SIZE` — fires when any `(size_class, target_zq)` training cell has fewer than `min_train_rows_per_size_zq` (default 50) rows.
  - `safety_report.diagnostics.train_rows_by_size_zq`: per-`(size, zq)` row counts. Forwarded into the bake manifest by the existing `safety_report` plumbing — no `bake_picker.py` change needed.
- **inference.rs / lib.rs**: confirmed the picker is feature-vector-in / argmin-out — size handling lives strictly at the codec edge. Added a docstring section to `lib.rs` documenting that and pointing at the structural gates around the runtime crate.
- **Cross-term audit**: `derive_extra_axes` already includes `log_pixels × every feat_*` and the size_class one-hot. The engineered input layout exercised by the new probe matches `train_hybrid.py:353-363` exactly so the post-bake gate sees what the runtime sees.

### 2. Intra-image-size generalization test — `tools/size_invariance_probe.py`

Post-bake stability check. Loads any baked picker JSON + a features TSV (output of the codec's `--features-only` sweep harness), samples `--n-images` (default 10) fixture images that cover all four size classes, and for each `(image, target_zq)` checks whether the picker's argmin cell stays stable across the four sizes. Reports per-image stability + corpus-level stability + top flips. Mirrors `tools/adversarial_probe.py`'s shape — same numpy-reference forward pass, same `--strict`/CI semantics. Exits 1 in `--strict` when stability < `--threshold` (default 90 %).

I picked the features-TSV path over a fresh Rust example because the user's prompt called out "fewer LOC to stand up" — the TSV is what the codec already produces, and the probe is ~290 LOC including extensive docstrings.

### 3. Documentation

- **`zenpicker/SAFETY_PLANE.md`** — new section "Size invariance is a safety property" near the top, explaining why this is on the same footing as OOD detection / verify-and-rescue.
- **`zenpicker/FOR_NEW_CODECS.md`** — new "Step 1.5 — sweep at all four size classes" between Steps 1 and 2, with a code excerpt from `zenjpeg/examples/zq_pareto_calibrate.rs:506-512` as the reference. Step 8's safety-gate list updated to include the two new violations.
- **`zenpicker/tools/README.md`** — canonical command sequence extended with the size-invariance probe (numbered step 6 in the script flow, fitting between bake-roundtrip and the existing adversarial probe). Safety-gate table updated.
- **`zenpicker/README.md`** — size-invariance gate marked ✅ v0.1 in the roadmap.

### 4. by_size safety threshold (the new threshold)

Wired up exactly as the prompt asked. The defaults were chosen so the existing v2.1 bake's `by_size` block does NOT trip `PER_SIZE_TAIL` (tiny p99 = 41.7 %, well under the 80 % ceiling). `DATA_STARVED_SIZE` may fire on existing bakes — see "Notes" below.

## Notes / data points

- **The `min_train_rows_per_size_zq=50` default may immediately fire on the existing v2.1 bake.** Tiny has 1871 train+val rows distributed over 36 zq targets ≈ ~52 rows / cell at the train split. Some `(tiny, zq)` cells could fall below 50 — this is a finding the user wants to see, not a problem to paper over. No re-bake shipped in this PR per the prompt's instructions.
- **`PER_SIZE_TAIL` is comfortable at 80 %** given v2.1's tiny p99 = 41.7 %. The user's prompt mentioned "max = 100 % would trip a strict ceiling" — `max_pct` isn't gated by this threshold; `max_single_row_overhead_pct=200` already covers the worst single-row case.
- **Smoke-tested the probe in both directions** with synthetic models: 100 % stability on a noise-only model, 0 % stability when `size_oh` weights dominate the bytes head. The strict-fail path exits 1 as expected.
- **No structural changes beyond the prompt's list.** The `lib.rs` docstring addition is the one thing not explicitly listed — it documents the architectural invariant ("the picker stays codec-agnostic; size invariance is a codec-edge concern") so future readers don't try to bake size-awareness into the runtime crate.

## Test plan

- [x] `cargo check -p zenpicker` — clean
- [x] `python3 -c "import ast; ast.parse(open('train_hybrid.py').read())"` — no syntax issues
- [x] `train_hybrid.count_train_rows_by_size_zq` unit-tested (synthetic `meta_tr`)
- [x] `safety_check` fires `PER_SIZE_TAIL` + `DATA_STARVED_SIZE` on a synthetic diag with the expected violation messages
- [x] `size_invariance_probe.py` end-to-end smoke (100 % stability on a noise-only model, 0 % stability on a size-dominated model)
- [ ] Re-run on a fresh v2.1-shape bake to see whether `DATA_STARVED_SIZE` fires (intentionally deferred — no re-bake in this PR)
- [ ] CI: `train_hybrid.py --strict` against the existing zenjpeg corpus — see if the new gates change the verdict