### PR TITLE
patch(zenpicker): ceiling-aware ZQ filter + UNCAPPED_ZQ_GRID safety gate

### DIFF
--- a/zenpicker/FOR_NEW_CODECS.md
+++ b/zenpicker/FOR_NEW_CODECS.md
@@ -20,7 +20,7 @@ The example throughout uses a hypothetical "zenwidget" codec with two scalar con
 Your codec runs every config × every quality value over a corpus and emits one row per `(image, size, config, quality)` cell:
 
 ```
-image_path<TAB>size_class<TAB>width<TAB>height<TAB>config_id<TAB>config_name<TAB>q<TAB>bytes<TAB>zensim<TAB>encode_ms<TAB>total_ms
+image_path<TAB>size_class<TAB>width<TAB>height<TAB>config_id<TAB>config_name<TAB>q<TAB>bytes<TAB>zensim<TAB>encode_ms<TAB>total_ms<TAB>effective_max_zensim
 ```
 
 | Column | Type | Notes |
@@ -33,6 +33,9 @@ image_path<TAB>size_class<TAB>width<TAB>height<TAB>config_id<TAB>config_name<TAB
 | `q` | int | 0..100 quality value swept |
 | `bytes` | int | Encoded byte count |
 | `zensim` | float | Achieved perceptual quality (zensim or compatible) |
+| `effective_max_zensim` | float | **Per `(image, size_class)`** — max zensim physically achievable for this image at this size. Identical across every `(config, q)` row of the same `(image, size_class)`. Computed by the sweep harness as a byproduct: `max(zensim across all configs at the highest q values)`. Required when `max(ZQ_TARGETS) > 85` — the trainer fails the `UNCAPPED_ZQ_GRID` safety gate without it. See imazen/zenanalyze#51 for cross-codec design context. |
+
+**Why `effective_max_zensim` is mandatory at high zq.** Tiny / complex images can't reach zensim 94+ regardless of encoder quality — q=100 max-method saturates well below that ceiling for sizes ≤ 48 px long-edge, with content-dependent transitions around 64. Without per-image ceilings the trainer treats unreachable cells as data-starved, when in fact they're physically impossible. With the column populated, the trainer skips out-of-reach `target_zq` rows for each `(image, size)` automatically — no silent miscalibration in the small+high-zq corner. The codec runtime should also accept an `UnreachableAction` enum on its target-zq API (`Error / ReturnClosest / Lossless`) so applications get a typed error rather than a silent under-shoot.
 
 For zenjpeg this is `zenjpeg/examples/zq_pareto_calibrate.rs`. Yours can be a one-shot binary — it just needs to enumerate configs and emit the rows.
 

--- a/zenpicker/tools/train_hybrid.py
+++ b/zenpicker/tools/train_hybrid.py
@@ -336,9 +336,31 @@ def _render_axis_value(axis: str, value) -> str:
 
 
 def load_pareto(path):
+    """Load the Pareto sweep TSV.
+
+    Returns `(rows, ceilings, has_ceiling_column)` where:
+      - rows: `{(image_path, size_class, w, h) -> [{"config_id", "bytes",
+        "zensim"}]}`.
+      - ceilings: `{(image_path, size_class) -> effective_max_zensim}` —
+        only populated if the sweep TSV declares the
+        `effective_max_zensim` column. The value is the max zensim score
+        physically achievable for that image at that size, computed by
+        the sweep harness as a byproduct (typically `max(zensim)` across
+        all configs at the highest q values).
+      - has_ceiling_column: True iff the sweep TSV declared
+        `effective_max_zensim`. Used by the trainer to gate the
+        UNCAPPED_ZQ_GRID safety check.
+
+    See imazen/zenanalyze#51 for the cross-codec design context.
+    """
     rows = defaultdict(list)
+    ceilings: dict = {}
+    has_ceiling_column = False
     with open(path) as f:
         rdr = csv.DictReader(f, delimiter="\t")
+        has_ceiling_column = (
+            rdr.fieldnames is not None and "effective_max_zensim" in rdr.fieldnames
+        )
         for r in rdr:
             try:
                 cid = int(r["config_id"])
@@ -349,7 +371,18 @@ def load_pareto(path):
             CONFIG_NAMES.setdefault(cid, r["config_name"])
             key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
             rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
-    return rows
+            if has_ceiling_column:
+                cv = r.get("effective_max_zensim", "")
+                if cv:
+                    try:
+                        # Per-(image, size) — value is identical across
+                        # all (config, q) rows of that key. Take first.
+                        ceil_key = (r["image_path"], r["size_class"])
+                        if ceil_key not in ceilings:
+                            ceilings[ceil_key] = float(cv)
+                    except ValueError:
+                        pass
+    return rows, ceilings, has_ceiling_column
 
 
 def load_features(path):
@@ -407,11 +440,18 @@ def build_cell_index():
 # ---------- Build training dataset ----------
 
 
-def build_dataset(pareto, feats, feat_cols, cells, config_to_cell, parsed_all):
+def build_dataset(pareto, feats, feat_cols, cells, config_to_cell, parsed_all,
+                  ceilings=None):
     """Per (image, size, zq) row, compute within-cell optimal:
        bytes_log[c]    = log(min bytes in cell c over configs that reach zq)
        scalars[axis][c] = scalar value of the within-cell optimal for axis
        reachable[c]    = 1 if any config in cell c reached zq, 0 otherwise
+
+    `ceilings`: optional `{(image, size_class) -> effective_max_zensim}`.
+    When provided, skips `target_zq > effective_max_zensim[image, size]
+    + CEILING_MARGIN` cells — those targets are physically unreachable
+    for that (image, size) and produce only data-starvation noise. See
+    imazen/zenanalyze#51.
 
     Returns (Xs, Xe, bytes_log, scalars, reach, meta) where `scalars` is
     a `dict[axis_name -> ndarray(n_rows, n_cells)]` keyed by SCALAR_AXES.
@@ -421,6 +461,11 @@ def build_dataset(pareto, feats, feat_cols, cells, config_to_cell, parsed_all):
     bytes_log_rows, reach_rows = [], []
     scalar_rows = {axis: [] for axis in SCALAR_AXES}
     meta = []
+    # Drop zq targets above ceiling - this margin. The margin lets
+    # the picker still see borderline cells where some images do reach
+    # the target and others don't.
+    CEILING_MARGIN = 0.0
+    skipped_above_ceiling = 0
 
     for (image, size, w, h), samples in pareto.items():
         feat_key = (image, size)
@@ -431,6 +476,11 @@ def build_dataset(pareto, feats, feat_cols, cells, config_to_cell, parsed_all):
         size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
         size_oh[SIZE_INDEX[size]] = 1.0
 
+        # Per-image zensim ceiling (only when sweep TSV declared it).
+        ceiling = None
+        if ceilings:
+            ceiling = ceilings.get((image, size))
+
         # Group samples by config to track per-config best.
         # (one config can have multiple q values; pareto-best for each
         # cell at each zq target is the cheapest config that crosses zq.)
@@ -439,6 +489,13 @@ def build_dataset(pareto, feats, feat_cols, cells, config_to_cell, parsed_all):
             by_cfg[s["config_id"]].append(s)
 
         for zq in ZQ_TARGETS:
+            # Ceiling-aware skip: targets above the per-image achievable
+            # max are physically unreachable (every cell will fail) —
+            # skip them so the picker doesn't waste capacity on
+            # impossible rows. See imazen/zenanalyze#51.
+            if ceiling is not None and zq > ceiling + CEILING_MARGIN:
+                skipped_above_ceiling += 1
+                continue
             cell_bytes = [math.inf] * n_cells
             cell_scalars = {axis: [math.nan] * n_cells for axis in SCALAR_AXES}
             cell_reach = [False] * n_cells
@@ -639,6 +696,14 @@ DEFAULT_SAFETY_THRESHOLDS = dict(
     # top of the zq grid (so the picker isn't always falling through
     # to KnownGoodFallback).
     min_safe_cells_at_top_zq=1,
+    # The sweep TSV must declare per-(image, size_class) zensim
+    # ceilings (`effective_max_zensim` column) when the codec's
+    # ZQ_TARGETS grid extends above this threshold. Without ceilings,
+    # the trainer can't tell DATA_STARVED_SIZE (sweep harness skipped
+    # cells) apart from physically-unreachable rows (perceptual
+    # metric saturated below target). Set to None to disable. See
+    # imazen/zenanalyze#51 for the cross-codec design context.
+    require_ceiling_above_zq=85,
 )
 
 
@@ -922,6 +987,32 @@ def safety_check(diag, thresholds, objective: str):
             f"have train rows < {thresholds['min_train_rows_per_size_zq']}: "
             f"{examples}{more}"
         )
+
+    # Sweep-side ceiling discipline. When the codec's ZQ_TARGETS grid
+    # extends above `require_ceiling_above_zq`, the sweep TSV MUST
+    # declare per-(image, size_class) zensim ceilings so the trainer
+    # can tell DATA_STARVED_SIZE (sweep harness gap) apart from
+    # physically-unreachable rows (perceptual metric saturated below
+    # target). Without this, every codec re-discovers the same lesson
+    # the hard way — silent miscalibration at small+high-zq corners.
+    # See imazen/zenanalyze#51.
+    require_ceiling_above_zq = thresholds.get("require_ceiling_above_zq")
+    sweep_ceilings = diag.get("sweep_ceilings", {})
+    if require_ceiling_above_zq is not None and sweep_ceilings:
+        max_target_zq = sweep_ceilings.get("max_target_zq", 0)
+        if max_target_zq > require_ceiling_above_zq and not sweep_ceilings.get(
+            "has_effective_max_zensim", False
+        ):
+            v.append(
+                f"UNCAPPED_ZQ_GRID: ZQ_TARGETS includes zq={max_target_zq} > "
+                f"{require_ceiling_above_zq} but Pareto TSV has no "
+                f"`effective_max_zensim` column. Trainer can't tell physically-"
+                f"unreachable cells apart from sweep gaps; DATA_STARVED_SIZE "
+                f"warnings cannot be diagnosed honestly. Either lower "
+                f"max(ZQ_TARGETS) below {require_ceiling_above_zq + 1} or have "
+                f"the codec sweep harness emit `effective_max_zensim` per "
+                f"(image, size_class). See imazen/zenanalyze#51."
+            )
 
     if diag["worst_case"]:
         worst = diag["worst_case"][0]
@@ -1238,9 +1329,19 @@ def main():
     )
 
     sys.stderr.write(f"Loading {PARETO}...\n")
-    pareto = load_pareto(PARETO)
+    pareto, ceilings, has_ceiling_column = load_pareto(PARETO)
     feats, feat_cols = load_features(FEATURES)
-    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features\n")
+    if has_ceiling_column:
+        n_with_ceiling = sum(1 for v in ceilings.values() if v is not None)
+        sys.stderr.write(
+            f"Loaded {len(pareto)} cells × {len(feat_cols)} features  "
+            f"({n_with_ceiling} (image, size_class) pairs declare effective_max_zensim)\n"
+        )
+    else:
+        sys.stderr.write(
+            f"Loaded {len(pareto)} cells × {len(feat_cols)} features  "
+            f"(sweep TSV has NO effective_max_zensim column — see imazen/zenanalyze#51)\n"
+        )
 
     cells, cell_id_by_key, config_to_cell, parsed_all = build_cell_index()
     n_cells = len(cells)
@@ -1249,7 +1350,8 @@ def main():
         sys.stderr.write(f"  {c['id']:>2d}: {c['label']:30s}  ({len(c['member_config_ids'])} configs)\n")
 
     Xs, Xe, bytes_log, scalars, reach, meta = build_dataset(
-        pareto, feats, feat_cols, cells, config_to_cell, parsed_all
+        pareto, feats, feat_cols, cells, config_to_cell, parsed_all,
+        ceilings=(ceilings if has_ceiling_column else None),
     )
     sys.stderr.write(
         f"\nDecision rows: {len(Xs)}; Xs={Xs.shape[1]}, Xe={Xe.shape[1]}, n_cells={n_cells}\n"
@@ -1432,6 +1534,16 @@ def main():
         "mlp": mlp_health,
         "feature_bounds": feature_bounds,
         "reach_safety": reach_safety,
+        # Sweep ceilings: did the codec's harness emit
+        # `effective_max_zensim` in the Pareto TSV? Drives the
+        # UNCAPPED_ZQ_GRID safety gate. See imazen/zenanalyze#51.
+        "sweep_ceilings": {
+            "has_effective_max_zensim": bool(has_ceiling_column),
+            "n_with_ceiling": int(
+                sum(1 for v in ceilings.values() if v is not None)
+            ) if has_ceiling_column else 0,
+            "max_target_zq": int(max(ZQ_TARGETS)) if ZQ_TARGETS else 0,
+        },
     }
     thresholds = dict(DEFAULT_SAFETY_THRESHOLDS)
     codec_thresholds = getattr(


### PR DESCRIPTION
## Summary

First-pass implementation of #51 — per-`(image, size_class)` zensim ceiling as a first-class TSV column, trainer-side filter, and a new safety gate that forces every codec to emit the column when training at high zq.

## What changes

**Pareto TSV schema** — gains an optional `effective_max_zensim` column per `(image, size_class)`. Identical across every `(config, q)` row of the same `(image, size_class)`. Computed by the codec sweep harness as a byproduct: `max(zensim across all configs at the highest q values)`.

**Trainer** (`zenpicker/tools/train_hybrid.py`):
- `load_pareto` returns `(rows, ceilings, has_ceiling_column)`.
- `build_dataset(..., ceilings=...)` skips `target_zq > effective_max_zensim[image, size]` cells. Those are physically unreachable for the perceptual metric (q=100 max-method saturates below zq 94 for tiny images); previously they showed up as DATA_STARVED_SIZE noise.
- New safety threshold `require_ceiling_above_zq` (default 85). When `max(ZQ_TARGETS) > 85` and the TSV has no `effective_max_zensim` column, the trainer fires an `UNCAPPED_ZQ_GRID` violation pointing to #51.
- New diagnostic block `sweep_ceilings` in the safety report (forwarded to manifest by `bake_picker.py` unchanged).

**Docs** — `FOR_NEW_CODECS.md` Step 1 updated with the new column; the `Why mandatory at high zq` paragraph documents the empirical findings (sizes ≤48 saturate well below zq 94 regardless of encoder quality, content-dependent transition near 64).

## Back-compat

- Codec configs that pre-date the column still train. The trainer logs a one-line note pointing to #51, fires `UNCAPPED_ZQ_GRID`, but does not crash.
- Existing safety profiles (`--strict`, `--allow-unsafe`) work unchanged. CI configurations that already use `--strict` will start failing on TSVs without the column at high zq — which is the intent.
- Bake tool (`bake_picker.py`) consumes the new manifest fields by default (they flow through the existing `safety_report` plumbing).

## Verification

Ran the patched trainer against zenjpeg's existing v2.2 sweep TSV (no ceiling column):

```
Loaded 1388 cells × 51 features  (sweep TSV has NO effective_max_zensim column — see imazen/zenanalyze#51)
Teacher metrics: argmin mean overhead 1.82% argmin_acc 57.8%
Student metrics: argmin mean overhead 3.66% argmin_acc 48.3%
  ⚠ SAFETY VIOLATIONS DETECTED — picker may produce dangerous results
  • UNCAPPED_ZQ_GRID: ZQ_TARGETS includes zq=100 > 85 but Pareto TSV has no
    `effective_max_zensim` column. Trainer can't tell physically-unreachable
    cells apart from sweep gaps; DATA_STARVED_SIZE warnings cannot be
    diagnosed honestly. Either lower max(ZQ_TARGETS) below 86 or have the
    codec sweep harness emit `effective_max_zensim` per (image, size_class).
    See imazen/zenanalyze#51.
Wrote benchmarks/zq_bytes_hybrid_v2_2_clean.json
```

Numerics match the prior baseline; the new violation surfaces honestly without breaking the existing pipeline.

## Empirical motivation

zenwebp ceiling probe on 25 representative images × 12 configs (q ∈ {90,92,94,96,98,100} × method ∈ {4,6}):

| size | max zensim achievable (q=100, m=6) |
|------|------------------------------------:|
| 32 | **75.4** (one image went **negative** — pie chart at q=100) |
| 48 | **70.1** |
| 64 | 96.1 — but only 1/5 images cleared 94 (a smooth photo); chart capped at 85.8 |
| 96 | 95.9 |
| 128 | 95.8 |

Sizes ≤48 hit a hard structural ceiling well below zq 94. Without `effective_max_zensim`, the picker training was treating ~600K cells as data-starved when they were physically impossible.

## Out of scope (follow-ups)

- Codec sweep harnesses emit the column. The schema is documented; each codec lands its own harness change.
- `zenanalyze::PredictedZensimCeiling` feature for the runtime predictor (per-image fast estimate at the API boundary, before encoding).
- Codec runtime `UnreachableAction` enum (`Error / ReturnClosest / Lossless`) so applications get a typed error instead of a silent under-shoot. Documented in the FOR_NEW_CODECS.md update.
- `SAFETY_PLANE.md` `UnreachableTargetZensim` runtime error documentation.

## Test plan

- [x] zenjpeg's existing TSV reproduces prior metrics with the new code path
- [x] Missing-column warning fires on TSVs without the column
- [x] UNCAPPED_ZQ_GRID violation fires when high-zq targets are paired with no ceiling
- [ ] zenwebp sweep harness lands the column (separate PR at imazen/zenwebp; this PR only changes upstream tooling)
- [ ] Codec runtime `UnreachableAction` follow-up (separate PR per codec)

Closes nothing yet — #51 stays open until the runtime contract + zenanalyze feature land. This PR is the load-bearing trainer-side piece that lets every codec start emitting the column.