### PR TITLE
fix(bake_picker): finite-f32 sentinels; docs: --activation leakyrelu is the fast path

### DIFF
--- a/tools/bake_picker.py
+++ b/tools/bake_picker.py
@@ -49,6 +49,7 @@ authoritative byte/JSON specs.
 import argparse
 import hashlib
 import json
+import math
 import os
 import shutil
 import struct
@@ -294,14 +295,30 @@ def encode_metadata(model: dict, out_path: Path) -> list[dict]:
     return entries
 
 
+# Finite f32 sentinels for "no bound" cells. JSON has no Infinity
+# literal; strict parsers (incl. zenpredict-bake's serde_json) reject
+# `-Infinity` / `Infinity` even though Python's json.dumps emits them
+# by default with `allow_nan=True`. Use values just inside f32 range
+# so the runtime OOD comparison treats them as "always in-bounds"
+# without overflowing on any side. f32::MAX ≈ 3.4028235e38.
+_FEATURE_BOUND_OPEN_LO = -3.4028235e38
+_FEATURE_BOUND_OPEN_HI = 3.4028235e38
+
+
 def encode_feature_bounds(model: dict, n_inputs: int, feat_cols: list[str]) -> list[dict]:
     """Build the v2 top-level feature_bounds Section from
     safety_report.diagnostics.feature_bounds.
 
     Output length must equal n_inputs (one bound per model input).
-    Engineered axes past feat_cols get (-inf, +inf) so they never
-    trigger the OOD gate. Returns an empty list when no bounds are
-    available — the loader emits an empty Section.
+    Engineered axes past feat_cols get the finite-f32-max "open"
+    sentinels so they never trigger the OOD gate. Returns an empty
+    list when no bounds are available — the loader emits an empty
+    Section.
+
+    Why finite sentinels and not Infinity: ZNPR v2 BakeRequestJson is
+    strict JSON and rejects `Infinity` / `-Infinity` literals. The
+    sentinels round-trip cleanly and behave identically in the
+    runtime OOD comparison (any feature value falls inside).
     """
     sr = model.get("safety_report")
     if not isinstance(sr, dict):
@@ -313,12 +330,28 @@ def encode_feature_bounds(model: dict, n_inputs: int, feat_cols: list[str]) -> l
     for col in feat_cols:
         s = fb.get(col)
         if isinstance(s, dict) and s.get("p01") is not None and s.get("p99") is not None:
-            out.append({"low": float(s["p01"]), "high": float(s["p99"])})
+            lo = float(s["p01"])
+            hi = float(s["p99"])
+            # Defensive: replace any non-finite training-side bound
+            # (a constant feature can produce NaN/inf percentiles) with
+            # the open sentinels so the JSON stays strict.
+            if not math.isfinite(lo):
+                lo = _FEATURE_BOUND_OPEN_LO
+            if not math.isfinite(hi):
+                hi = _FEATURE_BOUND_OPEN_HI
+            out.append({"low": lo, "high": hi})
         else:
-            out.append({"low": float("-inf"), "high": float("inf")})
-    # Pad to n_inputs with permissive bounds.
+            out.append({
+                "low": _FEATURE_BOUND_OPEN_LO,
+                "high": _FEATURE_BOUND_OPEN_HI,
+            })
+    # Pad to n_inputs with permissive bounds (engineered axes past
+    # feat_cols get the open sentinels).
     while len(out) < n_inputs:
-        out.append({"low": float("-inf"), "high": float("inf")})
+        out.append({
+            "low": _FEATURE_BOUND_OPEN_LO,
+            "high": _FEATURE_BOUND_OPEN_HI,
+        })
     return out
 
 

--- a/zentrain/FOR_NEW_CODECS.md
+++ b/zentrain/FOR_NEW_CODECS.md
@@ -171,15 +171,31 @@ def parse_config_name(name: str) -> dict:
 Then run from your codec's repo:
 
 ```bash
-PYTHONPATH=<zenanalyze>/zenpicker/examples:<zenanalyze>/zenpicker/tools \
+PYTHONPATH=<zenanalyze>/zentrain/examples:<zenanalyze>/zentrain/tools \
     python3 <zenanalyze>/zentrain/tools/train_hybrid.py \
-        --codec-config zenwidget_picker_config
+        --codec-config zenwidget_picker_config \
+        --activation leakyrelu
 ```
 
-End-to-end on a 16-core box: ~3 minutes wall-clock. Useful flags:
+**Use `--activation leakyrelu` for fast training.** The default
+`--activation relu` routes the student MLP fit through sklearn's
+single-threaded `MLPRegressor.fit`, which takes **~5–15 minutes** on
+this workload (each Adam matmul is too small for BLAS to extract
+parallelism, and sklearn has no batch-level parallelism). The
+`leakyrelu` path uses a PyTorch student with the same hidden shape,
+init, optimizer, and early-stopping — but runs in **~30 seconds to a
+few minutes** depending on capacity. Same numerics-class output JSON
+either way; the bake + runtime are activation-agnostic. Keep
+`--activation relu` only when you need bit-identical reproduction of
+a pre-leakyrelu sklearn-trained baseline.
+
+End-to-end on a 16-core box with `--activation leakyrelu`: ~30 seconds
+of MLP fit + ~30 seconds of HistGB teachers ≈ ~1 minute wall-clock
+total. With `--activation relu` it can stretch to ~10 minutes wall.
 
 | Flag | When |
 |---|---|
+| `--activation leakyrelu` | **Strongly recommended for new codecs.** Fast pytorch student. Default is sklearn-relu and is 10–20× slower at the same shape. |
 | `--objective {size_optimal, zensim_strict}` | size_optimal (default) trains mean log-bytes; zensim_strict trains pinball-q99 + per-zq reach gate. Ship both side-by-side |
 | `--bytes-quantile 0.99` | quantile for zensim_strict bytes head |
 | `--reach-threshold 0.99` | per-cell reach-rate floor for zensim_strict gate |

--- a/zentrain/examples/zenwebp_picker_config.py
+++ b/zentrain/examples/zenwebp_picker_config.py
@@ -1,0 +1,143 @@
+"""
+Codec config for zenwebp's hybrid-heads picker — v0.2 schema with the
+post-#42 zenanalyze dimension + percentile feature blocks. Pruned to
+36 features via the 2026-04-30 ablation.
+
+Used by `zentrain/tools/train_hybrid.py`. Defines paths to the Pareto
+sweep + features TSVs, the feature subset the picker consumes, the
+target_zq grid, the regex that parses zenwebp's config_name strings,
+and the explicit axis schema (categorical cells × scalar prediction
+heads).
+
+Run training from the zenwebp checkout:
+
+    cd ~/work/zen/zenwebp
+    PYTHONPATH=~/work/zen/zenanalyze/zentrain/examples:~/work/zen/zenanalyze/zentrain/tools \\
+        python3 ~/work/zen/zenanalyze/zentrain/tools/train_hybrid.py \\
+            --codec-config zenwebp_picker_config
+
+Cell taxonomy (CATEGORICAL_AXES — form cells):
+  - method ∈ {4, 5, 6}    — m0-3 omitted (below production quality floor)
+  - segments ∈ {1, 4}     — 2/3 omitted (rarely Pareto-winners)
+  → 6 cells
+
+Scalar prediction heads (SCALAR_AXES):
+  - sns_strength
+  - filter_strength
+  - filter_sharpness
+
+So 6 cells × (1 bytes_log + 3 scalars) = 24 output dimensions.
+
+The Pareto sweep emits config_name strings of the form:
+  `m{method}_seg{segments}_sns{sns}_fs{filter_strength}_sh{filter_sharpness}`
+e.g. `m4_seg1_sns0_fs0_sh0`, `m6_seg4_sns100_fs60_sh6`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# ---------- Paths ----------
+
+# zenwebp/dev/zenwebp_pareto.rs writes here. Bump dates when re-running
+# the sweep on a new corpus or with a new config grid.
+PARETO = Path("benchmarks/zenwebp_pareto_2026-04-30_combined.tsv")
+FEATURES = Path("benchmarks/zenwebp_pareto_features_2026-04-30_combined.tsv")
+
+OUT_JSON = Path("benchmarks/zenwebp_hybrid_2026-04-30.json")
+OUT_LOG = Path("benchmarks/zenwebp_hybrid_2026-04-30.log")
+
+
+# ---------- Schema ----------
+
+# Pruned schema from the 2026-04-30 v0.2 ablation pass (Δ ≥ +0.05pp on
+# permutation importance). 36 features that earn their keep — sorted
+# by importance descending.
+KEEP_FEATURES = [
+    # Top tier (Δ ≥ +0.20pp)
+    "feat_laplacian_variance_p50",
+    "feat_laplacian_variance_p75",
+    "feat_laplacian_variance",
+    "feat_quant_survival_y",
+    "feat_cb_sharpness",
+    "feat_pixel_count",
+    "feat_uniformity",
+    "feat_distinct_color_bins",
+    "feat_cr_sharpness",
+    "feat_edge_density",
+    "feat_noise_floor_y_p50",
+    "feat_luma_histogram_entropy",
+    # Mid tier (Δ +0.10..+0.20pp)
+    "feat_natural_likelihood",
+    "feat_quant_survival_y_p50",
+    "feat_noise_floor_uv_p50",
+    "feat_aq_map_mean",
+    "feat_cr_horiz_sharpness",
+    "feat_min_dim",
+    "feat_edge_slope_stdev",
+    "feat_laplacian_variance_p90",
+    "feat_patch_fraction",
+    "feat_max_dim",
+    "feat_aspect_min_over_max",
+    "feat_aq_map_p75",
+    # Low tier (Δ +0.05..+0.10pp)
+    "feat_cb_horiz_sharpness",
+    "feat_noise_floor_y_p25",
+    "feat_noise_floor_uv",
+    "feat_chroma_complexity",
+    "feat_quant_survival_y_p75",
+    "feat_aq_map_std",
+    "feat_gradient_fraction",
+    "feat_noise_floor_y_p75",
+    "feat_screen_content_likelihood",
+    "feat_high_freq_energy_ratio",
+    "feat_colourfulness",
+    "feat_quant_survival_uv",
+]
+
+# Zq target grid: production-relevant range. q < 30 corresponds to
+# extreme-low quality that's rarely shipped (the per-zq-tail safety
+# gate fired at zq=5 with 84.8% p99 overhead — that's just low-q
+# noise, not a picker miscalibration). Cap below at 30 to drop the
+# noise floor; cap above at 95 to stay below where data starvation
+# bites tiny/small images (see imazen/zenanalyze#51).
+ZQ_TARGETS = list(range(30, 70, 5)) + list(range(70, 96, 2))
+
+
+# ---------- Axis schema ----------
+
+CATEGORICAL_AXES = ["method", "segments"]
+SCALAR_AXES = ["sns_strength", "filter_strength", "filter_sharpness"]
+SCALAR_SENTINELS: dict = {}
+SCALAR_DISPLAY_RANGES = {
+    "sns_strength": (0, 100),
+    "filter_strength": (0, 100),
+    "filter_sharpness": (0, 7),
+}
+
+
+# ---------- Config-name parser ----------
+
+# Format: m{method}_seg{segments}_sns{sns}_fs{filter_strength}_sh{filter_sharpness}
+# Examples:
+#   m4_seg1_sns0_fs0_sh0      → method=4, segments=1, sns=0,   fs=0,  sh=0
+#   m6_seg4_sns100_fs60_sh6   → method=6, segments=4, sns=100, fs=60, sh=6
+_CONFIG_RE = re.compile(
+    r"^m(?P<method>\d+)_seg(?P<seg>\d+)"
+    r"_sns(?P<sns>\d+)_fs(?P<fs>\d+)_sh(?P<sh>\d+)$"
+)
+
+
+def parse_config_name(name: str) -> dict:
+    """Decompose a zenwebp config name into categorical + scalar axes."""
+    m = _CONFIG_RE.match(name)
+    if not m:
+        raise ValueError(f"unparseable zenwebp config name: {name}")
+    return {
+        "method": int(m.group("method")),
+        "segments": int(m.group("seg")),
+        "sns_strength": float(m.group("sns")),
+        "filter_strength": float(m.group("fs")),
+        "filter_sharpness": float(m.group("sh")),
+    }

--- a/zentrain/tools/README.md
+++ b/zentrain/tools/README.md
@@ -10,7 +10,7 @@ config-name parser. Then runs these scripts against that config.
 | File | Purpose |
 |---|---|
 | `_picker_lib.py` | Shared library: disk-cached dataset construction, parallel teacher training (joblib), HISTGB_FAST/FULL presets, subsample helper, StepTimer |
-| `train_hybrid.py` | **Recommended.** Hybrid-heads training: N categorical cells + K scalar prediction heads per cell. Codec supplies the cell taxonomy via `parse_config_name`. Flags: `--objective {size_optimal, zensim_strict}`, `--bytes-quantile`, `--reach-threshold`, `--hidden 192,192,192`, `--out-suffix` |
+| `train_hybrid.py` | **Recommended.** Hybrid-heads training: N categorical cells + K scalar prediction heads per cell. Codec supplies the cell taxonomy via `parse_config_name`. **Always pass `--activation leakyrelu`** for new bakes — the default `relu` routes through sklearn's single-threaded `MLPRegressor.fit` and is 10–20× slower at the same shape (sklearn keeps Adam matmuls below the BLAS-threading threshold; pytorch matches our actual wall-clock budget). Other flags: `--objective {size_optimal, zensim_strict}`, `--bytes-quantile`, `--reach-threshold`, `--hidden 192,192,192`, `--out-suffix` |
 | `train_distill.py` | Categorical-only distillation (legacy v1.x picker shape). Per-config HistGB teacher → small shared MLP student |
 | `train_distill_reduced.py` | Same as `train_distill.py` but with a reduced feature subset declared in the codec config |
 | `feature_ablation.py` | Per-feature importance ranking. **`--method permutation`** (default) — train once, shuffle each column, ~50× faster than LOO. `--method loo` retrains the model with each feature dropped (legacy ground truth). `--strict` exits 1 on features whose Δ is below `--max-negative-delta-pp` (overfit-on-noise signal) |

--- a/zentrain/tools/train_hybrid.py
+++ b/zentrain/tools/train_hybrid.py
@@ -1172,11 +1172,17 @@ def main():
         choices=["relu", "leakyrelu"],
         default="relu",
         help="Hidden-layer activation. relu (default) trains via "
-        "sklearn MLPRegressor. leakyrelu falls through to a PyTorch "
-        "student with negative_slope=0.01 — same MLP shape, same "
-        "Adam/lr/batch/early-stopping schedule. Both produce a "
+        "sklearn `MLPRegressor.fit`, which is single-threaded for "
+        "our matmul size and TYPICALLY 10–20× SLOWER than the "
+        "leakyrelu path. **Use `--activation leakyrelu` for new "
+        "bakes** — it falls through to a PyTorch student with "
+        "negative_slope=0.01 (same MLP shape, same Adam/lr/batch/"
+        "early-stopping schedule) and finishes in seconds-to-minutes "
+        "instead of minutes-to-hours. Both produce a "
         "`student.coefs_/intercepts_` surface so safety_check, "
-        "diagnostics, and JSON serialization work the same way.",
+        "diagnostics, and JSON serialization work the same way. "
+        "Keep `relu` only when you need bit-identical reproduction "
+        "of a pre-leakyrelu sklearn-trained baseline.",
     )
     parser.add_argument(
         "--seed",


### PR DESCRIPTION
Two stop-the-bleeding fixes for codec teams adopting zenpicker.

## 1. `bake_picker.py` Infinity → finite f32 sentinels

`tools/bake_picker.py::encode_feature_bounds` was emitting `-Infinity` / `Infinity` literals for engineered axes past `feat_cols` and for any feature whose training-side distribution lacked `p01`/`p99`. Strict JSON (which is what `zenpredict-bake`'s serde_json reads) rejects those literals.

Effect on every codec adoption: `zenpredict-bake` failed with

```
zenpredict-bake: JSON parse error in <path>: invalid number at line N column M
```

… and the codec team had to hand-clean the intermediate JSON before re-running. Hit it on the zenwebp picker wire-up (had to post-process with `sed s/-Infinity/-3.4028235e+38/g; s/Infinity/3.4028235e+38/g`).

Fix: replace the emit with finite f32-max sentinels (`-3.4028235e+38` / `+3.4028235e+38`). Round-trip cleanly through strict JSON and behave identically in the runtime OOD comparison (any plausible feature value falls inside).

Also defensive: any non-finite training-side bound (a constant feature can produce NaN/inf percentiles) is replaced with the same open sentinels.

## 2. `--activation leakyrelu` is the fast path — surface it in docs + --help

`train_hybrid.py`'s default `--activation relu` routes the student MLP fit through sklearn's single-threaded `MLPRegressor.fit`. On our typical (74-input × 128-hidden × batch=512, 24-output, ~14k row) workload it takes **5-15 minutes wall-clock**. Adam matmuls are too small for BLAS to extract parallelism, sklearn has no batch-level parallelism either.

`--activation leakyrelu` falls through to the PyTorch path (`_train_torch_leakyrelu_student`) with the same hidden shape, init, optimizer, and early-stopping schedule. **~30 seconds wall-clock** at the same shape — 10-20× faster.

The trainer's `--help` text mentioned both paths but didn't lead with the speed warning. The zenwebp adoption ran with the default and lost ~hours before realizing.

Updated:
- `zentrain/tools/train_hybrid.py` `--help` for `--activation`: leads with the 'sklearn-relu is 10-20x slower' caveat instead of burying it
- `zentrain/FOR_NEW_CODECS.md` Step 4: `--activation leakyrelu` example, wall-clock comparison table, recommendation framing
- `zentrain/tools/README.md`: same recommendation in the table entry for `train_hybrid.py`

Did NOT flip the default to `leakyrelu` — that's a behavior change for any pinned consumer that needs bit-identical reproduction of a pre-leakyrelu sklearn-trained baseline. Could be a follow-up once one cycle of bakes confirms the leakyrelu metrics are within tolerance.

## 3. zenwebp codec config (additive)

Adds `zentrain/examples/zenwebp_picker_config.py` — the v0.2 36-feature schema mirror for the zenwebp v0.1 picker. Cell taxonomy = `(method × segments) ∈ {(4,1),(4,4),(5,1),(5,4),(6,1),(6,4)}`. Mirrors `src/encoder/picker/spec.rs` in the imazen/zenwebp `spike/zenpicker-knobs` branch (which the upcoming zenwebp PR will graduate to `feat/picker-v0.1` once these upstream fixes land).

## Test plan

- [x] zenjpeg trainer reproduces v2.2 metrics with the doc-only changes (no behavior change to zenjpeg's pinned bakes)
- [x] `bake_picker.py` no longer emits `Infinity` literals; baked output is byte-identical for all-bounded inputs (only changes the unbounded sentinels)
- [x] zenwebp picker bake completes via the official `bake_picker.py` path without `--allow-unsafe`-side hand-cleaning of the intermediate JSON
- [ ] zenavif/zenjxl pickers: pick up the same fixes when their bakes land

Refs imazen/zenanalyze#51 for the cross-codec ceiling-aware design context (separate concern, not closed by this PR).