### PR TITLE
feat(zenwebp_picker_config): accept v0.1 config names alongside v0.2

### DIFF
--- a/zentrain/examples/zenwebp_picker_config.py
+++ b/zentrain/examples/zenwebp_picker_config.py
@@ -151,24 +151,53 @@ _CONFIG_RE = re.compile(
     r"_sns(?P<sns>\d+)_fs(?P<fs>\d+)_sh(?P<sh>\d+)"
     r"_pl(?P<pl>\d+)_mp(?P<mp>[01])$"
 )
+# Legacy v0.1 format (2026-04-29 / 2026-04-30 bakes): no
+# cost_model_strict / partition_limit / multi_pass_stats axes.
+# Older bakes on disk are still useful for ablation / comparison runs;
+# parse_config_name accepts both formats so student_permutation.py and
+# friends can re-load them without re-training.
+_CONFIG_RE_V01 = re.compile(
+    r"^m(?P<method>\d+)_seg(?P<seg>\d+)"
+    r"_sns(?P<sns>\d+)_fs(?P<fs>\d+)_sh(?P<sh>\d+)$"
+)
 
 
 def parse_config_name(name: str) -> dict:
-    """Decompose a zenwebp v0.2 config name into categorical + scalar
+    """Decompose a zenwebp config name into categorical + scalar
     axes. Categorical axes are method, segments, cost_model_strict;
-    everything else is a scalar prediction head."""
+    everything else is a scalar prediction head.
+
+    Accepts both:
+      - v0.2: ``m4_seg1_cm0_sns0_fs0_sh0_pl0_mp0`` (current bakes)
+      - v0.1: ``m4_seg1_sns0_fs0_sh0`` (2026-04-29 / 2026-04-30 bakes
+        before cm/pl/mp axes were added). v0.1 rows default
+        cost_model_strict=False, partition_limit=0, multi_pass_stats=0
+        — i.e. they slot into the v0.2 cell that matches the legacy
+        defaults so a v0.1 bake's outputs are interpretable under the
+        v0.2 schema.
+    """
     m = _CONFIG_RE.match(name)
-    if not m:
-        raise ValueError(f"unparseable zenwebp config name: {name}")
-    return {
-        # categorical
-        "method": int(m.group("method")),
-        "segments": int(m.group("seg")),
-        "cost_model_strict": bool(int(m.group("cm"))),
-        # scalar
-        "sns_strength": float(m.group("sns")),
-        "filter_strength": float(m.group("fs")),
-        "filter_sharpness": float(m.group("sh")),
-        "partition_limit": float(m.group("pl")),
-        "multi_pass_stats": float(m.group("mp")),
-    }
+    if m:
+        return {
+            "method": int(m.group("method")),
+            "segments": int(m.group("seg")),
+            "cost_model_strict": bool(int(m.group("cm"))),
+            "sns_strength": float(m.group("sns")),
+            "filter_strength": float(m.group("fs")),
+            "filter_sharpness": float(m.group("sh")),
+            "partition_limit": float(m.group("pl")),
+            "multi_pass_stats": float(m.group("mp")),
+        }
+    m = _CONFIG_RE_V01.match(name)
+    if m:
+        return {
+            "method": int(m.group("method")),
+            "segments": int(m.group("seg")),
+            "cost_model_strict": False,
+            "sns_strength": float(m.group("sns")),
+            "filter_strength": float(m.group("fs")),
+            "filter_sharpness": float(m.group("sh")),
+            "partition_limit": 0.0,
+            "multi_pass_stats": 0.0,
+        }
+    raise ValueError(f"unparseable zenwebp config name: {name}")


### PR DESCRIPTION
## Summary

Companion to #63 (now merged). When running `student_permutation.py` against any of the existing zenwebp bakes on disk:

```
~/work/zen/zenwebp/benchmarks/zenwebp_hybrid_2026-04-{29,30}*.json
```

`parse_config_name` raises `unparseable zenwebp config name: m4_seg1_sns0_fs0_sh0` because every one of those bakes uses the **v0.1 config-name format** while the current parser only matches **v0.2**.

This patch adds a v0.1 fallback regex with sensible defaults (`cost_model_strict=False`, `partition_limit=0`, `multi_pass_stats=0`) so historical bakes can still be loaded for ablation / comparison without re-training.

zenavif's `rav1e_picker_config.py` already follows this pattern (separate v0.1/v0.2 regexes, shared dict-builder); this brings zenwebp into line.

## Test plan

Manual smoke test (no automated test infra exists for these config modules yet):

```python
from zenwebp_picker_config import parse_config_name

# v0.2 (current bakes)
assert parse_config_name('m6_seg4_cm1_sns100_fs60_sh6_pl100_mp0') == {
    'method': 6, 'segments': 4, 'cost_model_strict': True,
    'sns_strength': 100.0, 'filter_strength': 60.0, 'filter_sharpness': 6.0,
    'partition_limit': 100.0, 'multi_pass_stats': 0.0,
}

# v0.1 (2026-04-29 / 2026-04-30 bakes)
assert parse_config_name('m4_seg1_sns0_fs0_sh0') == {
    'method': 4, 'segments': 1, 'cost_model_strict': False,
    'sns_strength': 0.0, 'filter_strength': 0.0, 'filter_sharpness': 0.0,
    'partition_limit': 0.0, 'multi_pass_stats': 0.0,
}

# Bad input still raises
parse_config_name('garbage')   # → ValueError
```

All three pass on this branch.

## Why default `cost_model_strict=False`?

That's what zenwebp's v0.1 sweep harness was actually setting — v0.1 rows match the cell that v0.2 produces for `(method, segments, cost_model_strict=False)`, so the picker's cell mapping is preserved across the schema bump. Same for `partition_limit=0` and `multi_pass_stats=0`.

## Out of scope / follow-ups

- A unit test for both formats would be nice; the codec-config modules don't have a tests directory yet, so left out.
- The v0.1 zenwebp bakes themselves are reaching end-of-life (v0.2 retraining is the path forward); this PR exists so the historical artifacts stay analyzable until they age out.
- rav1e and zenjpeg picker configs already handle multi-format gracefully; zenavif's was modeled on zenjpeg's pattern earlier today.

Surfaced during cross-codec ablation for #63: https://github.com/imazen/zenanalyze/pull/63#issuecomment-4358289751