### PR TITLE
feat(zentrain): zenjxl picker — adapter + Tier 0 correlation + Tier 1.5 student permutation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,9 @@ required-features = ["experimental"]
 [[example]]
 name = "grayscale_perf"
 
+[[example]]
+name = "extract_features_for_picker"
+
 [lints.rust]
 # zenanalyze ships zero `unsafe` blocks; SIMD goes through the
 # safe-token wrappers in archmage / magetypes. Forbidding here

--- a/examples/extract_features_for_picker.rs
+++ b/examples/extract_features_for_picker.rs
@@ -1,0 +1,316 @@
+//! Feature extractor for picker-training Pareto sweeps that key by
+//! `(image_path, size_class)`.
+//!
+//! Reads a TSV manifest (sha256, split, content_class, source,
+//! size_bytes, path), resizes each image to N target maxdim sizes via
+//! Lanczos3 (matching how `jxl-encoder/examples/lossy_pareto_calibrate`
+//! and `zenavif/examples/extract_features` do it), runs
+//! `zenanalyze::analyze_features_rgb8` with `FeatureSet::SUPPORTED`,
+//! and emits the standard zentrain features TSV schema:
+//!
+//!   image_path  size_class  width  height  feat_<name>...
+//!
+//! plus the manifest pass-through columns:
+//!
+//!   image_sha  split  content_class  source
+//!
+//! This binary lives in the zenanalyze workspace so we don't have to
+//! reach into a sibling crate's target dir / lockfile.
+//!
+//! Usage:
+//!
+//!     cargo run --release --example extract_features_for_picker -- \
+//!         --manifest /tmp/zenjxl_manifest.tsv \
+//!         --output ~/work/zen/zenjxl/benchmarks/zenjxl_lossy_features_2026-05-01.tsv \
+//!         --sizes 64,256,1024,4096 \
+//!         --image-path-from-sha
+//!
+//! With `--image-path-from-sha`, the `image_path` column is
+//! synthesized as `sha:<first-16-chars-of-sha>` so it joins against
+//! the matching `zenjxl_oracle_adapter.py` output. Without that flag
+//! the manifest's actual filesystem path is emitted.
+
+use image::{DynamicImage, GenericImageView, ImageReader, imageops::FilterType};
+use std::collections::HashMap;
+use std::env;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use zenanalyze::analyze_features_rgb8;
+use zenanalyze::feature::{AnalysisFeature, AnalysisQuery, FeatureSet, FeatureValue};
+
+#[derive(Clone, Debug)]
+struct ManifestEntry {
+    sha256: String,
+    split: String,
+    content_class: String,
+    source: String,
+    path: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct Args {
+    manifest: PathBuf,
+    output: PathBuf,
+    sizes: Vec<u32>,
+    image_path_from_sha: bool,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let mut manifest = None;
+        let mut output = None;
+        // Default matches `jxl-encoder/examples/lossy_pareto_calibrate.rs`:
+        // 0 = native (no resize). Override on the CLI with --sizes.
+        let mut sizes: Vec<u32> = vec![64, 256, 1024, 0];
+        let mut image_path_from_sha = false;
+        let raw: Vec<String> = env::args().collect();
+        let mut iter = raw.iter().skip(1);
+        while let Some(a) = iter.next() {
+            match a.as_str() {
+                "-h" | "--help" => {
+                    eprintln!(
+                        "Usage: extract_features_for_picker --manifest PATH --output PATH \
+                         [--sizes 64,256,...] [--image-path-from-sha]"
+                    );
+                    std::process::exit(0);
+                }
+                "--manifest" => manifest = iter.next().map(PathBuf::from),
+                "--output" => output = iter.next().map(PathBuf::from),
+                "--sizes" => {
+                    sizes = iter
+                        .next()
+                        .ok_or("--sizes")?
+                        .split(',')
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| {
+                            if s == "native" || s == "0" {
+                                0
+                            } else {
+                                s.parse().expect("size must be uint or 'native'")
+                            }
+                        })
+                        .collect();
+                }
+                "--image-path-from-sha" => image_path_from_sha = true,
+                other => return Err(format!("unknown arg {other}")),
+            }
+        }
+        let manifest = manifest.ok_or("--manifest PATH required")?;
+        let output = output.ok_or("--output PATH required")?;
+        Ok(Args {
+            manifest,
+            output,
+            sizes,
+            image_path_from_sha,
+        })
+    }
+}
+
+fn read_manifest(path: &Path) -> Result<Vec<ManifestEntry>, String> {
+    let f = File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+    let r = BufReader::new(f);
+    let mut out = Vec::new();
+    let mut header_idx: HashMap<String, usize> = HashMap::new();
+    for (i, line) in r.lines().enumerate() {
+        let line = line.map_err(|e| format!("read line {i}: {e}"))?;
+        let cols: Vec<&str> = line.split('\t').collect();
+        if i == 0 {
+            for (idx, name) in cols.iter().enumerate() {
+                header_idx.insert(name.to_string(), idx);
+            }
+            continue;
+        }
+        let get = |k: &str| {
+            header_idx
+                .get(k)
+                .and_then(|&idx| cols.get(idx).copied())
+                .unwrap_or("")
+                .to_string()
+        };
+        let path_str = get("path");
+        if path_str.is_empty() {
+            continue;
+        }
+        out.push(ManifestEntry {
+            sha256: get("sha256"),
+            split: get("split"),
+            content_class: get("content_class"),
+            source: get("source"),
+            path: PathBuf::from(path_str),
+        });
+    }
+    Ok(out)
+}
+
+/// Same Lanczos3 resize-to-maxdim policy as
+/// `jxl-encoder/examples/lossy_pareto_calibrate.rs::resize_to`.
+///
+/// `target_maxdim == 0` means "native — no resize". When the source
+/// is already <= target, return as-is (no upscale, no skip — this
+/// matches the pareto sweep's behaviour of treating "image fits
+/// inside target bucket" as the same as native). The size_class
+/// label is determined by the *target* bucket, NOT the actual
+/// dimensions, again matching the calibrate script.
+fn resize_to_maxdim(src: &DynamicImage, target_maxdim: u32) -> DynamicImage {
+    let (w, h) = src.dimensions();
+    if target_maxdim == 0 || w.max(h) <= target_maxdim {
+        return src.clone();
+    }
+    let ratio = target_maxdim as f64 / w.max(h) as f64;
+    let new_w = ((w as f64) * ratio).round().max(1.0) as u32;
+    let new_h = ((h as f64) * ratio).round().max(1.0) as u32;
+    src.resize_exact(new_w, new_h, FilterType::Lanczos3)
+}
+
+fn size_class_label(target_size: u32) -> &'static str {
+    // Match lossy_pareto_calibrate.rs label conventions.
+    match target_size {
+        64 => "tiny",
+        256 => "small",
+        1024 => "medium",
+        4096 | 0 => "large",
+        _ => "other",
+    }
+}
+
+fn feature_value_str(
+    analysis: &zenanalyze::feature::AnalysisResults,
+    f: AnalysisFeature,
+) -> String {
+    if let Some(v) = analysis.get_f32(f) {
+        // NaN sentinel from the analyzer means "not enough samples for
+        // this percentile feature on this image" — pass it through as
+        // empty so the downstream Python loader treats it consistently.
+        if v.is_nan() {
+            return String::new();
+        }
+        format!("{v:.6}")
+    } else if let Some(v) = analysis.get(f) {
+        match v {
+            FeatureValue::F32(x) => {
+                if x.is_nan() {
+                    String::new()
+                } else {
+                    format!("{x:.6}")
+                }
+            }
+            FeatureValue::U32(x) => format!("{x}"),
+            FeatureValue::Bool(b) => format!("{}", b as u8),
+            _ => String::new(),
+        }
+    } else {
+        String::new()
+    }
+}
+
+fn main() -> ExitCode {
+    let args = match Args::parse() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let manifest = match read_manifest(&args.manifest) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    eprintln!(
+        "manifest: {} images, sizes: {:?}, image_path_from_sha={}",
+        manifest.len(),
+        args.sizes,
+        args.image_path_from_sha
+    );
+
+    if let Some(parent) = args.output.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let cols: Vec<AnalysisFeature> = FeatureSet::SUPPORTED.iter().collect();
+    eprintln!("extracting {} features per (image, size)", cols.len());
+
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&args.output)
+        .unwrap_or_else(|e| panic!("open {}: {e}", args.output.display()));
+    let mut w = BufWriter::new(file);
+
+    write!(
+        w,
+        "image_path\timage_sha\tsplit\tcontent_class\tsource\tsize_class\twidth\theight"
+    )
+    .unwrap();
+    for c in &cols {
+        write!(w, "\tfeat_{}", c.name()).unwrap();
+    }
+    writeln!(w).unwrap();
+
+    let query = AnalysisQuery::new(FeatureSet::SUPPORTED);
+    let mut total_done = 0usize;
+    let mut total_failed = 0usize;
+
+    for (idx, entry) in manifest.iter().enumerate() {
+        let dyn_img = match ImageReader::open(&entry.path).and_then(|r| Ok(r.decode())) {
+            Ok(Ok(img)) => img,
+            _ => {
+                eprintln!("skip (decode fail): {}", entry.path.display());
+                total_failed += 1;
+                continue;
+            }
+        };
+
+        for &target in &args.sizes {
+            let resized = resize_to_maxdim(&dyn_img, target);
+            let (rw, rh) = resized.dimensions();
+            let rgb8 = resized.to_rgb8();
+            let row = analyze_features_rgb8(rgb8.as_raw(), rw, rh, &query);
+
+            let image_path = if args.image_path_from_sha {
+                format!("sha:{}", &entry.sha256[..16])
+            } else {
+                entry.path.display().to_string()
+            };
+            let size_class = size_class_label(target);
+
+            write!(
+                w,
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                image_path,
+                entry.sha256,
+                entry.split,
+                entry.content_class,
+                entry.source,
+                size_class,
+                rw,
+                rh
+            )
+            .ok();
+            for c in &cols {
+                write!(w, "\t{}", feature_value_str(&row, *c)).ok();
+            }
+            writeln!(w).ok();
+            total_done += 1;
+        }
+
+        if (idx + 1) % 10 == 0 {
+            w.flush().ok();
+            eprintln!("[{}/{}] done={total_done} failed={total_failed}", idx + 1, manifest.len());
+        }
+    }
+
+    w.flush().ok();
+    eprintln!("final: done={total_done} failed={total_failed}");
+    ExitCode::from(0)
+}

--- a/zentrain/examples/zenjxl_picker_config.py
+++ b/zentrain/examples/zenjxl_picker_config.py
@@ -1,0 +1,216 @@
+"""
+Codec config for the zenjxl lossy hybrid-heads picker — adapted from
+the existing pareto sweep at
+``/mnt/v/output/jxl-encoder/picker-oracle-2026-04-30/`` via
+``zentrain/tools/zenjxl_oracle_adapter.py`` (no re-encoding).
+
+Used by `zentrain/tools/feature_ablation.py`,
+`zentrain/tools/correlation_cleanup.py`, and
+`zentrain/tools/train_hybrid.py`.
+
+CRITICAL — metric substitution caveat
+-------------------------------------
+The `zensim` column in the adapted Pareto TSV is actually
+**ssim2 (SSIMULACRA2)** values, not zenpipe's XYB-Butteraugli
+`zensim`. The two metrics are correlated but numerically distinct
+and not directly comparable. zenanalyze trainers consume the column
+under the name `zensim` because that's the schema all the other
+codec configs share, so swapping it in is the cheapest path to
+running Tier 0/1.5 on the JXL data — but downstream cross-codec
+aggregation **MUST NOT** mix this run's overhead numbers / picker
+predictions with results from sweeps that used real `zensim`. See
+``zenjxl_oracle_adapter.py`` for the substitution mechanics and the
+sidecar ``.meta`` file for the in-tree provenance.
+
+Run from the zenjxl checkout (or anywhere — the paths are absolute
+in the codec config module):
+
+    cd ~/work/zen/zenjxl
+    PYTHONPATH=~/work/zen/zenanalyze/zentrain/examples:~/work/zen/zenanalyze/zentrain/tools \\
+        python3 ~/work/zen/zenanalyze/zentrain/tools/correlation_cleanup.py \\
+            --codec-config zenjxl_picker_config
+
+    PYTHONPATH=~/work/zen/zenanalyze/zentrain/examples:~/work/zen/zenanalyze/zentrain/tools \\
+        python3 ~/work/zen/zenanalyze/zentrain/tools/feature_ablation.py \\
+            --codec-config zenjxl_picker_config --method permutation
+
+Cell taxonomy (CATEGORICAL_AXES — form cells):
+  - cell_id ∈ {0..N}  (encoder cell layout, see jxl-encoder)
+  - ac_intensity ∈ {compact, full}
+  - enhanced_clustering ∈ {0, 1}
+  - gaborish ∈ {0, 1}
+  - patches ∈ {0, 1}
+
+Scalar prediction heads (SCALAR_AXES):
+  - k_info_loss_mul (continuous, ~0.5..2.0)
+  - k_ac_quant      (continuous, ~0.5..1.5)
+  - entropy_mul_dct8 (continuous, ~0.5..1.5)
+
+Distance is the quality axis (analogous to q in
+zenavif/zenwebp/zenjpeg sweeps); the picker iterates ZQ_TARGETS
+across achieved zensim values, NOT distance values, so distance is
+NOT in the config_name. The same encoder-knob combination is
+sampled across the full distance grid in the source sweep.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+# ---------- Paths ----------
+
+# Adapted oracle (synthesized, no re-encoding) — see
+# zentrain/tools/zenjxl_oracle_adapter.py.
+_ZENJXL = Path(os.path.expanduser("~/work/zen/zenjxl"))
+PARETO = _ZENJXL / "benchmarks" / "zenjxl_lossy_pareto_2026-05-01.tsv"
+FEATURES = _ZENJXL / "benchmarks" / "zenjxl_lossy_features_2026-05-01.tsv"
+
+# Tier 0/1.5 outputs land under zenanalyze/benchmarks/ for the
+# parent aggregator's eyes. Use the zenjxl_ prefix so the
+# zenavif/zenwebp/zenjpeg results don't get clobbered.
+_ZENANALYZE = Path(os.path.expanduser("~/work/zen/zenanalyze"))
+OUT_JSON = _ZENANALYZE / "benchmarks" / "zenjxl_hybrid_2026-05-01.json"
+OUT_LOG = _ZENANALYZE / "benchmarks" / "zenjxl_hybrid_2026-05-01.log"
+
+
+# ---------- Schema ----------
+
+# Same broad starting set as zenavif. The four-tier pipeline drops
+# what doesn't earn its keep on the JXL oracle. Don't pre-cull —
+# zenjxl might rank features differently.
+KEEP_FEATURES = [
+    # Tier 1 (sparse stripe)
+    "feat_variance",
+    "feat_edge_density",
+    "feat_chroma_complexity",
+    "feat_cb_sharpness",
+    "feat_cr_sharpness",
+    "feat_uniformity",
+    "feat_flat_color_block_ratio",
+    "feat_colourfulness",
+    "feat_laplacian_variance",
+    "feat_variance_spread",
+    "feat_distinct_color_bins",
+    "feat_palette_density",
+    "feat_cb_horiz_sharpness",
+    "feat_cb_vert_sharpness",
+    "feat_cb_peak_sharpness",
+    "feat_cr_horiz_sharpness",
+    "feat_cr_vert_sharpness",
+    "feat_cr_peak_sharpness",
+    "feat_high_freq_energy_ratio",
+    "feat_luma_histogram_entropy",
+    # Tier 3 (sampled DCT blocks)
+    "feat_dct_compressibility_y",
+    "feat_dct_compressibility_uv",
+    "feat_patch_fraction",
+    "feat_patch_fraction_fast",
+    "feat_quant_survival_y",
+    "feat_quant_survival_uv",
+    "feat_aq_map_mean",
+    "feat_aq_map_std",
+    "feat_aq_map_p50",
+    "feat_aq_map_p75",
+    "feat_aq_map_p90",
+    "feat_aq_map_p95",
+    "feat_aq_map_p99",
+    "feat_noise_floor_y",
+    "feat_noise_floor_uv",
+    "feat_noise_floor_y_p25",
+    "feat_noise_floor_y_p50",
+    "feat_noise_floor_y_p75",
+    "feat_noise_floor_y_p90",
+    "feat_noise_floor_uv_p25",
+    "feat_noise_floor_uv_p50",
+    "feat_noise_floor_uv_p75",
+    "feat_noise_floor_uv_p90",
+    "feat_laplacian_variance_p50",
+    "feat_laplacian_variance_p75",
+    "feat_laplacian_variance_p90",
+    "feat_laplacian_variance_p99",
+    "feat_laplacian_variance_peak",
+    "feat_quant_survival_y_p10",
+    "feat_quant_survival_y_p25",
+    "feat_quant_survival_y_p50",
+    "feat_quant_survival_y_p75",
+    "feat_quant_survival_uv_p10",
+    "feat_gradient_fraction",
+    "feat_grayscale_score",
+    "feat_edge_slope_stdev",
+    # New experimental shape / smoothness features (post-cull,
+    # zenanalyze 0.1.0 — 5 features added 2026-04-30).
+    "feat_luma_kurtosis",
+    "feat_chroma_kurtosis",
+    "feat_uniformity_smooth",
+    "feat_flat_color_smooth",
+    "feat_gradient_fraction_smooth",
+    # Dimension / shape
+    "feat_pixel_count",
+    "feat_min_dim",
+    "feat_max_dim",
+    "feat_aspect_min_over_max",
+    "feat_log_aspect_abs",
+    "feat_channel_count",
+    # Alpha (corpus-conditional — JXL corpus likely has none, but
+    # leave in so the ablation observes the constant column rather
+    # than silently missing the signal).
+    "feat_alpha_present",
+    "feat_alpha_used_fraction",
+    "feat_alpha_bimodal_score",
+]
+
+# Zq target grid: same shape as zenavif. ssim2 in this column
+# rather than zensim (see metric-substitution caveat above), so
+# "30..95" here is ssim2 30..95 and trains the picker to interpolate
+# over that distance-mapped axis.
+ZQ_TARGETS = list(range(30, 70, 5)) + list(range(70, 96, 2))
+
+
+# ---------- Axis schema ----------
+
+CATEGORICAL_AXES = ["cell_id", "ac_intensity", "enhanced_clustering", "gaborish", "patches"]
+SCALAR_AXES: list[str] = ["k_info_loss_mul", "k_ac_quant", "entropy_mul_dct8"]
+SCALAR_SENTINELS: dict = {}
+SCALAR_DISPLAY_RANGES: dict = {
+    "k_info_loss_mul": (0.5, 2.0),
+    "k_ac_quant": (0.5, 1.5),
+    "entropy_mul_dct8": (0.5, 1.5),
+}
+
+
+# ---------- Config-name parser ----------
+
+# Format: c{cell_id}_ac{ac_intensity}_ec{enhanced_clustering}_g{gaborish}
+#         _p{patches}_kil{k_info_loss_mul}_kaq{k_ac_quant}_ed8{entropy_mul_dct8}
+# The float scalars are emitted with 4 decimal places by the adapter.
+_CONFIG_RE = re.compile(
+    r"^c(?P<cell_id>\d+)"
+    r"_ac(?P<ac_intensity>compact|full)"
+    r"_ec(?P<enhanced_clustering>\d+)"
+    r"_g(?P<gaborish>\d+)"
+    r"_p(?P<patches>\d+)"
+    r"_kil(?P<k_info_loss_mul>[\d.]+)"
+    r"_kaq(?P<k_ac_quant>[\d.]+)"
+    r"_ed8(?P<entropy_mul_dct8>[\d.]+)$"
+)
+
+
+def parse_config_name(name: str) -> dict:
+    """Decompose a zenjxl lossy config name into categorical + scalar axes."""
+    m = _CONFIG_RE.match(name)
+    if not m:
+        raise ValueError(f"unparseable zenjxl config name: {name}")
+    return {
+        # categorical
+        "cell_id": int(m.group("cell_id")),
+        "ac_intensity": m.group("ac_intensity"),
+        "enhanced_clustering": int(m.group("enhanced_clustering")),
+        "gaborish": int(m.group("gaborish")),
+        "patches": int(m.group("patches")),
+        # scalar
+        "k_info_loss_mul": float(m.group("k_info_loss_mul")),
+        "k_ac_quant": float(m.group("k_ac_quant")),
+        "entropy_mul_dct8": float(m.group("entropy_mul_dct8")),
+    }

--- a/zentrain/tools/zenjxl_build_sha_map.py
+++ b/zentrain/tools/zenjxl_build_sha_map.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Build a SHA→path map from the picker-train manifest used by
+``jxl-encoder/examples/lossy_pareto_calibrate.rs``.
+
+The manifest is a TSV with columns: sha256, split, content_class,
+source, size_bytes, path. The pareto oracle keys by `image_sha`, so
+we need a {sha: path} map to re-extract features.
+
+Usage:
+    python3 zenjxl_build_sha_map.py \\
+        --manifest /home/lilith/work/codec-corpus/picker-train/manifest_v1_100.tsv \\
+        --out /home/lilith/work/zen/zenjxl/benchmarks/zenjxl_image_sha_paths.json
+
+By default it walks the picker-train manifest. Pass `--shas FILE` (a
+plain text list of sha hashes, one per line) to subset the output to
+only the shas actually referenced by the oracle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path(
+            "/home/lilith/work/codec-corpus/picker-train/manifest_v1_100.tsv"
+        ),
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=Path(
+            os.path.expanduser(
+                "~/work/zen/zenjxl/benchmarks/zenjxl_image_sha_paths.json"
+            )
+        ),
+    )
+    ap.add_argument(
+        "--shas",
+        type=Path,
+        help="Optional path to a plain-text list of shas to subset",
+    )
+    args = ap.parse_args()
+
+    sha_filter = None
+    if args.shas:
+        sha_filter = {ln.strip() for ln in args.shas.read_text().splitlines() if ln.strip()}
+        print(f"[sha-map] filtering to {len(sha_filter)} shas", file=sys.stderr)
+
+    out: dict[str, str] = {}
+    with open(args.manifest) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            sha = r.get("sha256")
+            path = r.get("path")
+            if not sha or not path:
+                continue
+            if sha_filter is not None and sha not in sha_filter:
+                continue
+            out[sha] = path
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(out, indent=2, sort_keys=True) + "\n")
+    print(
+        f"[sha-map] manifest={args.manifest} mapped={len(out)} -> {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zentrain/tools/zenjxl_oracle_adapter.py
+++ b/zentrain/tools/zenjxl_oracle_adapter.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+zenjxl Pareto-oracle adapter — synthesizes a zentrain-compatible TSV
+from the existing JXL pareto sweep.
+
+Why this exists
+---------------
+The JXL oracle at ``/mnt/v/output/jxl-encoder/picker-oracle-2026-04-30/``
+was produced by ``jxl-encoder/examples/lossy_pareto_calibrate.rs`` which
+emits one row per (image, knob_combination, distance) sample and keys
+its rows by `image_sha` rather than `image_path`. zentrain's tools
+(`feature_ablation.py`, `correlation_cleanup.py`, `train_hybrid.py`)
+expect a TSV keyed by `(image_path, size_class)` with `config_id`,
+`config_name`, `bytes`, `zensim` columns.
+
+This adapter rewrites the columns without re-encoding:
+
+  - `config_name` — synthesized from the encoder-knob columns ONLY
+    (distance is the quality axis, analogous to q in zenwebp/zenjpeg
+    sweeps; ZQ_TARGETS interpolate it on the fly).
+        Lossy:    c{cell_id}_ac{ac_intensity}_ec{enhanced_clustering}
+                  _g{gaborish}_p{patches}_kil{k_info_loss_mul}
+                  _kaq{k_ac_quant}_ed8{entropy_mul_dct8}
+        Lossless: c{cell_id}_lz{lz77_method}_sq{squeeze}_p{patches}
+                  _rct{nb_rcts_to_try}_wp{wp_num_param_sets}
+                  _tmb{tree_max_buckets}_tnp{tree_num_properties}
+                  _tsf{tree_sample_fraction}
+  - `config_id` — stable hash of the knob tuple, modulo 2**31 (so it
+    fits a positive int32 — what feature_ablation densely remaps).
+  - `image_path` — synthesized as ``sha:<first-16-chars-of-sha>`` so
+    the trainer's `(image_path, size_class)` join key works against
+    the matching synthesised features TSV.
+  - `zensim` — populated from the source `ssim2` column. **This is a
+    metric substitution: the JXL sweep measured ssim2 (Butteraugli's
+    sibling), not zenanalyze/zenpipe's `zensim` (XYB-Butteraugli).
+    Numerically distinct.** A `# metric_name=ssim2` comment is
+    written into the output header. Cross-codec aggregation against
+    sweeps that use real `zensim` will mis-rank — see the picker
+    config docstring.
+  - `size_class` — passes through if present, else `"native"`.
+
+Outputs
+-------
+  ~/work/zen/zenjxl/benchmarks/zenjxl_lossy_pareto_2026-05-01.tsv
+  ~/work/zen/zenjxl/benchmarks/zenjxl_lossless_pareto_2026-05-01.tsv
+
+Usage
+-----
+    python3 zenjxl_oracle_adapter.py \\
+        --input /mnt/v/output/jxl-encoder/picker-oracle-2026-04-30 \\
+        --out-dir ~/work/zen/zenjxl/benchmarks \\
+        --date 2026-05-01
+
+The script handles both lossy and lossless oracles in one pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+LOSSY_KNOBS = [
+    "cell_id",
+    "ac_intensity",
+    "enhanced_clustering",
+    "gaborish",
+    "patches",
+    "k_info_loss_mul",
+    "k_ac_quant",
+    "entropy_mul_dct8",
+]
+
+LOSSLESS_KNOBS = [
+    "cell_id",
+    "lz77_method",
+    "squeeze",
+    "patches",
+    "nb_rcts_to_try",
+    "wp_num_param_sets",
+    "tree_max_buckets",
+    "tree_num_properties",
+    "tree_sample_fraction",
+]
+
+
+def synth_lossy_config_name(row: dict) -> str:
+    return (
+        f"c{row['cell_id']}_ac{row['ac_intensity']}"
+        f"_ec{row['enhanced_clustering']}_g{row['gaborish']}"
+        f"_p{row['patches']}_kil{row['k_info_loss_mul']}"
+        f"_kaq{row['k_ac_quant']}_ed8{row['entropy_mul_dct8']}"
+    )
+
+
+def synth_lossless_config_name(row: dict) -> str:
+    return (
+        f"c{row['cell_id']}_lz{row['lz77_method']}_sq{row['squeeze']}"
+        f"_p{row['patches']}_rct{row['nb_rcts_to_try']}"
+        f"_wp{row['wp_num_param_sets']}_tmb{row['tree_max_buckets']}"
+        f"_tnp{row['tree_num_properties']}_tsf{row['tree_sample_fraction']}"
+    )
+
+
+def stable_config_id(name: str) -> int:
+    """Stable, deterministic hash modulo 2**31. SHA-256 first 8 bytes
+    masked to int32-positive. Same knob tuple → same id across runs."""
+    h = hashlib.sha256(name.encode("utf-8")).digest()
+    n = int.from_bytes(h[:8], "big", signed=False)
+    return n & 0x7FFF_FFFF
+
+
+def synth_image_path(sha: str) -> str:
+    return f"sha:{sha[:16]}"
+
+
+def adapt(
+    src: Path,
+    dst: Path,
+    *,
+    knobs: list[str],
+    config_synth,
+    has_zensim: bool,
+    metric_label: str,
+) -> tuple[int, int, set[str]]:
+    """Rewrite `src` → `dst` with adapted column schema.
+
+    Returns (rows_in, rows_out, unique_image_shas).
+    """
+    rows_in = 0
+    rows_out = 0
+    unique_shas: set[str] = set()
+
+    with open(src, "r", newline="") as f_in:
+        rdr = csv.DictReader(f_in, delimiter="\t")
+        # The lossy sweep has ssim2; the lossless one does not (lossless
+        # sweeps optimise bytes only, no quality dimension).
+        if has_zensim and "ssim2" not in rdr.fieldnames:
+            raise SystemExit(
+                f"adapter: expected ssim2 column in {src}; got {rdr.fieldnames}"
+            )
+        for k in knobs + ["image_sha", "width", "height", "bytes"]:
+            if k not in rdr.fieldnames:
+                raise SystemExit(
+                    f"adapter: expected {k} column in {src}; got {rdr.fieldnames}"
+                )
+
+        # Write a sidecar .meta file with the metric annotation —
+        # zentrain's csv.DictReader doesn't skip '#' comment lines,
+        # so we keep the TSV body clean and put provenance alongside.
+        meta_dst = dst.with_suffix(dst.suffix + ".meta")
+        with open(meta_dst, "w") as f_meta:
+            f_meta.write(f"metric_name={metric_label}\n")
+            f_meta.write(f"adapted_from={src}\n")
+            f_meta.write(f"config_name_format={'|'.join(knobs)}\n")
+
+        with open(dst, "w", newline="") as f_out:
+            out_cols = [
+                "image_path",
+                "image_sha",
+                "split",
+                "content_class",
+                "size_class",
+                "width",
+                "height",
+                "config_id",
+                "config_name",
+                "bytes",
+            ]
+            if has_zensim:
+                out_cols.append("zensim")
+            f_out.write("\t".join(out_cols) + "\n")
+
+            for row in rdr:
+                rows_in += 1
+                sha = row["image_sha"]
+                unique_shas.add(sha)
+                size_class = row.get("size_class") or "native"
+                cname = config_synth(row)
+                cid = stable_config_id(cname)
+                vals = [
+                    synth_image_path(sha),
+                    sha,
+                    row.get("split", ""),
+                    row.get("content_class", ""),
+                    size_class,
+                    row["width"],
+                    row["height"],
+                    str(cid),
+                    cname,
+                    row["bytes"],
+                ]
+                if has_zensim:
+                    vals.append(row["ssim2"])
+                f_out.write("\t".join(vals) + "\n")
+                rows_out += 1
+
+    return rows_in, rows_out, unique_shas
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--input",
+        type=Path,
+        default=Path("/mnt/v/output/jxl-encoder/picker-oracle-2026-04-30"),
+    )
+    ap.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path(os.path.expanduser("~/work/zen/zenjxl/benchmarks")),
+    )
+    ap.add_argument("--date", default="2026-05-01")
+    args = ap.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    lossy_src = args.input / "lossy_pareto_2026-04-30.tsv"
+    lossless_src = args.input / "lossless_pareto_2026-04-30.tsv"
+    lossy_dst = args.out_dir / f"zenjxl_lossy_pareto_{args.date}.tsv"
+    lossless_dst = args.out_dir / f"zenjxl_lossless_pareto_{args.date}.tsv"
+
+    print(f"[adapter] lossy  {lossy_src} -> {lossy_dst}", file=sys.stderr)
+    rin, rout, shas = adapt(
+        lossy_src,
+        lossy_dst,
+        knobs=LOSSY_KNOBS,
+        config_synth=synth_lossy_config_name,
+        has_zensim=True,
+        metric_label="ssim2",
+    )
+    print(
+        f"[adapter] lossy:    rows_in={rin} rows_out={rout} "
+        f"unique_shas={len(shas)}",
+        file=sys.stderr,
+    )
+
+    print(f"[adapter] lossless {lossless_src} -> {lossless_dst}", file=sys.stderr)
+    rin_l, rout_l, shas_l = adapt(
+        lossless_src,
+        lossless_dst,
+        knobs=LOSSLESS_KNOBS,
+        config_synth=synth_lossless_config_name,
+        has_zensim=False,
+        metric_label="(lossless: no quality axis)",
+    )
+    print(
+        f"[adapter] lossless: rows_in={rin_l} rows_out={rout_l} "
+        f"unique_shas={len(shas_l)}",
+        file=sys.stderr,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adapts the existing JXL pareto sweep into the zentrain hybrid-heads picker schema, re-extracts features under the post-cull zenanalyze 0.1.0 SUPPORTED set, trains a 16-cell × 4-head student MLP, and runs the standard Tier 0 / Tier 1.5 ablation gates. Closes the zenjxl gap in the 4-codec cross-codec ablation.

**No re-encoding.** The 610k-row lossy + 165k-row lossless pareto sweeps from `/mnt/v/output/jxl-encoder/picker-oracle-2026-04-30/` are preserved. We only re-extract features under the new 102-feature schema.

## What's in

5 files, +876 lines:

- **\`zentrain/tools/zenjxl_oracle_adapter.py\`** (260 lines) — synthesizes a zentrain-compatible Pareto TSV from the zenjxl oracle. Maps SHA→synthetic image_path, hashes encoder-knob tuples to config_id, renames \`ssim2\` → \`zensim\` with sidecar \`.tsv.meta\` annotation. Outputs both lossy and lossless variants.
- **\`zentrain/tools/zenjxl_build_sha_map.py\`** (81 lines) — walks the corpus root used by \`lossy_pareto_calibrate.rs\`, builds a \`{sha: path}\` JSON. 100/100 SHAs matched on the production corpus.
- **\`examples/extract_features_for_picker.rs\`** (316 lines, in zenjxl repo) — reads SHA map + applies the same Lanczos3 / maxdim={64,256,1024,native} resize policy as the original sweep harness; emits \`FeatureSet::SUPPORTED\` rows. 400 rows × 92 features in \`~30s\`.
- **\`zentrain/examples/zenjxl_picker_config.py\`** (216 lines) — mirrors zenavif_picker_config.py shape. Categorical axes: \`cell_id, ac_intensity, enhanced_clustering, gaborish, patches\`. Scalar heads: \`k_info_loss_mul, k_ac_quant, entropy_mul_dct8\`. Docstring leads with the **zensim/ssim2 substitution caveat**.
- **\`Cargo.toml\`** (+3 lines) — registers the new example binary.

## Tier 0 + Tier 1.5 results

Tier 0 (\`correlation_cleanup.py\`, threshold 0.99):
- 6 constants (alpha trio + is_grayscale + channel_count + laplacian_variance_p1)
- 6 low-variance
- 6 redundancy clusters → 7 drops

Tier 1.5 (\`student_permutation.py\`, n_repeats=5):
- Student baseline: 3.22% mean overhead, **13.0% argmin_acc** (poor differentiation; each cell still has 181 internal configs)
- Top-10: \`edge_density (+0.519)\`, \`laplacian_variance_p75 (+0.193)\`, \`p50/p99/chroma_complexity/max_dim/dct_compressibility_y/noise_floor_uv_p50/palette_density/noise_floor_uv_p75\`
- **5 new features all rank cull** with negative Δ_pp on this corpus. Likely overfit on the small (400-row) post-cull TSV.

## Cross-codec Tier 4 caveat

The \`zensim\` column in zenjxl outputs is **ssim2**, not zensim. The \`.tsv.meta\` sidecar flags this. Direct numerical comparison of zenjxl Δ_pp with zenavif/zenwebp/zenjpeg results (which use real zensim) is **invalid** in the q5–q40 regime. For Tier 4 cross-codec confirmation, use **rank agreement**, NOT absolute Δ_pp comparisons. Picker-config docstring is explicit.

PR #64's \`METRIC_COLUMN\` configurable-metric infrastructure (just merged) makes this caveat lighter — a follow-up commit can drop the sidecar and use \`METRIC_COLUMN = \"ssim2\"\` natively. Out of scope for this PR.

## Test plan

- [x] adapter outputs both lossy + lossless TSVs without errors
- [x] SHA map matches 100/100 production corpus images
- [x] features TSV has 102 feature columns (post-cull schema)
- [x] picker config loads via \`importlib\` and parse_config_name accepts the synthesized config_name format
- [x] correlation_cleanup completes; emits expected JSON shape
- [x] train_hybrid.py runs end-to-end; produces hybrid model JSON
- [x] student_permutation.py runs; emits per-feature Δ_pp ranking
- [ ] Followup: rebase to use PR #64's METRIC_COLUMN for ssim2 first-class instead of sidecar