### PR TITLE
deps: bump garb to 0.2.8 (tokenless deinterleave API)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ magetypes = { version = "0.9.23", features = ["avx512"] }
 # `bgra_to_rgb`, etc.) via `archmage::incant!` — used by the
 # `RowStream::StripAlpha8` fast path. Measured ~7× speedup over the
 # in-tree scalar strip on a 2048-px row (0.13 µs vs 0.94 µs at 4 MP).
-garb = { version = "0.2.7", default-features = false, features = ["experimental"] }
+garb = { version = "0.2.8", default-features = false, features = ["experimental"] }
 # `transfer` feature exposes scalar PQ / HLG / sRGB / BT.709 EOTFs used by
 # the source-direct HDR / depth tier (`tier_depth`).
 linear-srgb = { version = "0.6.12", features = ["transfer"] }

--- a/src/tier1.rs
+++ b/src/tier1.rs
@@ -58,10 +58,10 @@ mod deinterleave_dispatch {
     #[cfg(target_arch = "x86_64")]
     #[arcane]
     fn rgb24_chunk8_via_garb_v3(
-        token: archmage::X64V3Token,
+        _token: archmage::X64V3Token,
         chunk: &[u8; 24],
     ) -> ([f32; 8], [f32; 8], [f32; 8]) {
-        garb::deinterleave::rgb24_chunk8_to_planes_v3(token, chunk)
+        garb::deinterleave::rgb24_chunk8_to_planes_tokenless_v3(chunk)
     }
 
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
garb v0.2.7 was yanked because it shipped two public APIs that took an `archmage::X64V3Token` parameter, coupling garb's semver to archmage's. v0.2.8 replaces them 1:1 with tokenless equivalents decorated `#[rite(v3)]`; behavior is identical, signature drops the token.

## What changes

`Cargo.toml`: pin `garb = "0.2.7"` → `"0.2.8"`.

`src/tier1.rs::deinterleave_dispatch::rgb24_chunk8_via_garb_v3`:

```diff
-fn rgb24_chunk8_via_garb_v3(
-    token: archmage::X64V3Token,
-    chunk: &[u8; 24],
-) -> ([f32; 8], [f32; 8], [f32; 8]) {
-    garb::deinterleave::rgb24_chunk8_to_planes_v3(token, chunk)
-}
+fn rgb24_chunk8_via_garb_v3(
+    _token: archmage::X64V3Token,
+    chunk: &[u8; 24],
+) -> ([f32; 8], [f32; 8], [f32; 8]) {
+    garb::deinterleave::rgb24_chunk8_to_planes_tokenless_v3(chunk)
+}
```

The helper keeps `_token` in its signature because `#[arcane]` reads the token type to apply target_feature; we just don't forward it into garb anymore. The `_scalar` callers on this path (NEON, wasm128, ScalarToken) are unchanged — those signatures didn't move in garb 0.2.8.

## Why now

garb 0.2.7 is yanked. Without this bump, `cargo update` resolves zenanalyze's `garb = "0.2.7"` pin to 0.2.8 (caret), which then fails to compile because `rgb24_chunk8_to_planes_v3(token, ...)` no longer exists. This PR is the source-fix that goes with the yank.

## Public API

Internal change. zenanalyze's public surface is unchanged — per CLAUDE.md the crate is locked to additive 0.1.x changes, and this migration is purely an internal call-site rename in `tier1::deinterleave_dispatch`.

## Test plan

- [x] `cargo build --release --features experimental` passes
- [x] `cargo test --release --features experimental --lib` — 140 tests pass, 2 ignored, 0 failed

## Tracking

imazen/garb#7