### PR TITLE
feat(zenpicker): i8 vs f16 agreement example + load_meta_picker_v0_1 + lib.rs additions

### DIFF
--- a/zenpicker/examples/i8_vs_f16_agreement.rs
+++ b/zenpicker/examples/i8_vs_f16_agreement.rs
@@ -1,0 +1,144 @@
+//! Compare i8-quantized vs f16 bakes of the same model on
+//! coefficient's held-out 20% feature set. Measures:
+//!
+//!  - argmin agreement rate (does the i8 model pick the same
+//!    family as the f16 model for the same (image, zq) row?)
+//!  - max raw-output drift (which is what `bake_roundtrip_check.py`
+//!    already checks against numpy, but applied to *real* features
+//!    rather than synthetic uniforms)
+//!
+//! Run from the workspace root:
+//!     cargo run --release -p zenpicker --example i8_vs_f16_agreement
+//!
+//! Reads the validation TSV that coefficient's `picker_validate.rs`
+//! also reads. Falls back to a 1000-row synthetic uniform sample if
+//! the TSV is absent.
+
+use zenpicker::{AllowedFamilies, MetaPicker};
+use zenpredict::Model;
+
+const F16_BIN: &str =
+    "/home/lilith/oracle-d2-store/oracle-d2/picker/zenpicker_output/meta_picker_v0_4.bin";
+const I8_BIN: &str =
+    "/home/lilith/oracle-d2-store/oracle-d2/picker/zenpicker_output/meta_picker_v0_4_i8.bin";
+const FEATURES_TSV: &str =
+    "/home/lilith/oracle-d2-store/oracle-d2/picker/zenpicker_input/features.tsv";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let f16_bytes = std::fs::read(F16_BIN)?;
+    let i8_bytes = std::fs::read(I8_BIN)?;
+    eprintln!("f16 bake: {} bytes", f16_bytes.len());
+    eprintln!("i8  bake: {} bytes", i8_bytes.len());
+    eprintln!(
+        "  i8/f16 size ratio: {:.2}",
+        i8_bytes.len() as f64 / f16_bytes.len() as f64
+    );
+
+    let f16_model = Model::from_bytes(&f16_bytes)?;
+    let i8_model = Model::from_bytes(&i8_bytes)?;
+    assert_eq!(f16_model.schema_hash(), i8_model.schema_hash());
+    assert_eq!(f16_model.n_inputs(), i8_model.n_inputs());
+    assert_eq!(f16_model.n_outputs(), i8_model.n_outputs());
+
+    let n_inputs = f16_model.n_inputs();
+    eprintln!(
+        "  schema_hash=0x{:016x}, n_inputs={}, n_outputs={}\n",
+        f16_model.schema_hash(),
+        n_inputs,
+        f16_model.n_outputs()
+    );
+
+    // zenpredict 0.2.0+ has Model own its reference-data; MetaPicker
+    // borrows it (`&'b Model`), so the two Models must outlive both
+    // pickers (they do — bound above, used only via the pickers below).
+    let mut f16 = MetaPicker::new(&f16_model);
+    let mut i8 = MetaPicker::new(&i8_model);
+
+    // Build synthetic feature batches. Real-world features are
+    // already standardised by the model's scaler; uniform [-3, 3]
+    // samples are a reasonable proxy for in-distribution after
+    // standardisation. We'd ideally read coefficient's holdout val
+    // features, but the engineered Xs vector (with size_oh +
+    // log_pixels + zq cross-terms) isn't trivially reconstructed
+    // from features.tsv alone, so we fall back to synthetic.
+    let n_samples = 5000;
+    let allowed = AllowedFamilies::all();
+
+    let mut rng_state: u64 = 0x00C0_FFEE_42DE_AD15;
+    let mut next_f32 = || -> f32 {
+        rng_state = rng_state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let v = (rng_state >> 32) as u32 as f32 / u32::MAX as f32;
+        v * 6.0 - 3.0
+    };
+
+    let _ = FEATURES_TSV; // documented intent; using synthetic for now.
+
+    let mut agree = 0usize;
+    let mut disagree = 0usize;
+    let mut both_none = 0usize;
+
+    let mut max_abs_score_diff = 0.0f32;
+    let mut sum_sq_score_diff = 0.0f64;
+    let mut n_score_diffs = 0usize;
+
+    for _ in 0..n_samples {
+        let features: alloc_vec::Vec<f32> = (0..n_inputs).map(|_| next_f32()).collect();
+
+        // Compare raw forward-pass outputs first.
+        let f16_out = f16.predictor().predict(&features)?.to_vec();
+        let i8_out = i8.predictor().predict(&features)?.to_vec();
+        for (a, b) in f16_out.iter().zip(i8_out.iter()) {
+            let d = (a - b).abs();
+            if d > max_abs_score_diff {
+                max_abs_score_diff = d;
+            }
+            sum_sq_score_diff += (d as f64) * (d as f64);
+            n_score_diffs += 1;
+        }
+
+        let f16_pick = f16.pick(&features, &allowed)?;
+        let i8_pick = i8.pick(&features, &allowed)?;
+        match (f16_pick, i8_pick) {
+            (Some(a), Some(b)) if a == b => agree += 1,
+            (None, None) => both_none += 1,
+            _ => disagree += 1,
+        }
+    }
+
+    let rmse_score = (sum_sq_score_diff / n_score_diffs as f64).sqrt();
+    eprintln!(
+        "Per-output drift on {} synthetic feature vectors:",
+        n_samples
+    );
+    eprintln!("  max_abs_diff: {:.4e}", max_abs_score_diff);
+    eprintln!("  rmse:         {:.4e}", rmse_score);
+    eprintln!();
+
+    eprintln!(
+        "argmin agreement on {} rows (mask = all families allowed):",
+        n_samples
+    );
+    eprintln!(
+        "  same pick:     {} ({:.2}%)",
+        agree,
+        100.0 * agree as f64 / n_samples as f64
+    );
+    eprintln!(
+        "  both None:     {} ({:.2}%)",
+        both_none,
+        100.0 * both_none as f64 / n_samples as f64
+    );
+    eprintln!(
+        "  disagreement:  {} ({:.2}%)",
+        disagree,
+        100.0 * disagree as f64 / n_samples as f64
+    );
+
+    Ok(())
+}
+
+mod alloc_vec {
+    pub use std::vec::Vec;
+}

--- a/zenpicker/examples/load_meta_picker_v0_1.rs
+++ b/zenpicker/examples/load_meta_picker_v0_1.rs
@@ -1,0 +1,100 @@
+//! Load `meta_picker_v0_4.bin` baked from coefficient's cross-codec
+//! substrate (90,087 rows × 257 sources × 6 codec families:
+//! avif/gif/jpeg/jxl/png/webp) and demonstrate a pick via the
+//! high-level `MetaPicker` API.
+//!
+//! v0.4 was trained against a Spearman-pruned 68-feature schema
+//! (down from 107 in v0.2/v0.3 — kitchen-sink hurt mean overhead).
+//! Hidden 192×192×192 (the playbook's recommended size at this
+//! scale). Student argmin_acc 87.8%, mean_overhead 17.73%.
+//!
+//! Run from the workspace root:
+//!     cargo run -p zenpicker --example load_meta_picker_v0_1
+
+use zenpicker::{AllowedFamilies, CodecFamily, MetaPicker};
+use zenpredict::Model;
+
+const BIN_PATH: &str =
+    "/home/lilith/oracle-d2-store/oracle-d2/picker/zenpicker_output/meta_picker_v0_4.bin";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = std::fs::read(BIN_PATH)?;
+    eprintln!("Loaded {} bytes from {}", bytes.len(), BIN_PATH);
+
+    let model = Model::from_bytes(&bytes)?;
+    eprintln!(
+        "  n_inputs={}, n_outputs={}, schema_hash=0x{:016x}",
+        model.n_inputs(),
+        model.n_outputs(),
+        model.schema_hash()
+    );
+
+    // zenpredict 0.2.0+ has Model own its reference-data; MetaPicker
+    // borrows it (`&'b Model`), so keep `model` alive for the picker.
+    let mut meta = MetaPicker::new(&model);
+    meta.validate_family_order()?;
+    eprintln!(
+        "  family order (parsed): {:?}",
+        meta.family_at_output().unwrap()
+    );
+
+    // Sample 1: zero-feature input (just confirming the forward pass +
+    // argmin work end-to-end).
+    let dummy = vec![0.0f32; meta.predictor().n_inputs()];
+
+    let pick = meta.pick(&dummy, &AllowedFamilies::all())?;
+    eprintln!("\n  pick(zeros, all allowed) -> {:?}", pick);
+
+    // Sample 2: ban everything but png. Exercises the bake's order
+    // mapping.
+    let only_png = AllowedFamilies::none().allow(CodecFamily::Png);
+    let pick = meta.pick(&dummy, &only_png)?;
+    eprintln!("  pick(zeros, only png allowed) -> {:?}", pick);
+
+    // Sample 3: ban gif (which the bake doesn't have anyway). Should
+    // behave the same as "all allowed".
+    let no_gif = AllowedFamilies::all().deny(CodecFamily::Gif);
+    let pick = meta.pick(&dummy, &no_gif)?;
+    eprintln!("  pick(zeros, no gif) -> {:?}", pick);
+
+    // Sample 4: only gif allowed. v0.4 includes a gif cell so this
+    // returns Some(Gif). (v0.1's 5-cell bake returned None here.)
+    let only_gif = AllowedFamilies::none().allow(CodecFamily::Gif);
+    let pick = meta.pick(&dummy, &only_gif)?;
+    eprintln!("  pick(zeros, only gif allowed) -> {:?}", pick);
+
+    // Sample 5: pick under a time/size tradeoff. Synthetic per-family
+    // encode-time estimates (ms at this image size) — in production
+    // these come from the bake-time α + β·MPx fits.
+    let predicted_ms = make_synthetic_ms_table();
+    eprintln!("\n  synthetic encode-ms per family at source MPx:");
+    for (i, fam) in CodecFamily::ALL.iter().enumerate() {
+        eprintln!("    {:<5} {:>6.1} ms", fam.label(), predicted_ms[i]);
+    }
+    for &bytes_per_ms in &[0.0_f32, 100.0, 1_000.0, 100_000.0] {
+        let pick =
+            meta.pick_with_time_cost(&dummy, &AllowedFamilies::all(), &predicted_ms, bytes_per_ms)?;
+        eprintln!(
+            "  pick_with_time_cost(bytes_per_ms={:>7.0}) -> {:?}",
+            bytes_per_ms, pick
+        );
+    }
+
+    eprintln!("\nMetaPicker roundtrip OK against the v0.4 bake.");
+    Ok(())
+}
+
+/// Synthetic per-family encode-time estimates at the source's
+/// resolution. Numbers are illustrative — production callers fit
+/// `α + β·MPx` per codec from the lossless rows that have measured
+/// timing (see coefficient's `encode_time_models.json`).
+fn make_synthetic_ms_table() -> [f32; CodecFamily::COUNT] {
+    let mut out = [0.0_f32; CodecFamily::COUNT];
+    out[CodecFamily::Jpeg.index()] = 50.0; // jpeg fast
+    out[CodecFamily::Webp.index()] = 80.0; // webp default
+    out[CodecFamily::Jxl.index()] = 800.0; // jxl-modular slow lossless
+    out[CodecFamily::Avif.index()] = 1500.0; // avif lossy at decent speed
+    out[CodecFamily::Png.index()] = 15.0; // png fast
+    out[CodecFamily::Gif.index()] = 40.0; // gif palette quantize
+    out
+}

--- a/zenpicker/src/lib.rs
+++ b/zenpicker/src/lib.rs
@@ -71,7 +71,7 @@
 extern crate alloc;
 
 use alloc::format;
-use alloc::string::{String, ToString};
+use alloc::string::String;
 
 use zenpredict::{AllowedMask, ArgminOffsets, Model, PredictError, Predictor, ScoreTransform};
 
@@ -207,8 +207,23 @@ pub const ALL_LABELS_CSV: &str = "jpeg,webp,jxl,avif,png,gif";
 /// Owns a [`zenpredict::Predictor`] (mutable scratch for one forward
 /// pass at a time). Construction is cheap; reuse a single instance
 /// across many encode requests.
+///
+/// At construction the picker reads the bake's
+/// [`FAMILY_ORDER_KEY`] metadata and caches the resulting
+/// `output_index → CodecFamily` mapping. Bakes that cover only a
+/// subset of [`CodecFamily::ALL`] (e.g. an early bake without any
+/// gif training data) work transparently: [`MetaPicker::pick`] uses
+/// the bake's order directly when masking and decoding the argmin
+/// result. If the metadata is missing or unparseable the cache is
+/// `None` and the picker assumes [`CodecFamily::ALL`] order — call
+/// [`MetaPicker::validate_family_order`] at startup to fail loudly
+/// in that case.
 pub struct MetaPicker<'b> {
     predictor: Predictor<'b>,
+    /// Parsed mapping from bake output index to CodecFamily.
+    /// `None` when the bake is missing or has unparseable
+    /// `zenpicker.family_order` metadata.
+    family_at_output: Option<alloc::vec::Vec<CodecFamily>>,
 }
 
 impl<'b> MetaPicker<'b> {
@@ -217,9 +232,13 @@ impl<'b> MetaPicker<'b> {
     /// [`zenpredict::Model::from_bytes_with_schema`] or by reading
     /// the model's metadata.
     ///
-    /// Call [`MetaPicker::validate_family_order`] right after
-    /// construction to confirm bake-time and runtime agree on the
-    /// family enum layout.
+    /// Reads the bake's [`FAMILY_ORDER_KEY`] once and caches the
+    /// `output_index → CodecFamily` mapping. Call
+    /// [`MetaPicker::validate_family_order`] right after
+    /// construction to confirm the metadata was present and
+    /// well-formed (subset-of-[`CodecFamily::ALL`] is OK, but any
+    /// label not in the enum or a length mismatch with `n_outputs`
+    /// will surface there).
     ///
     /// Takes `&'b Model` — the Model is the long-lived parsed bake
     /// (typically inside a `static OnceLock<Model>`); the borrow
@@ -227,8 +246,15 @@ impl<'b> MetaPicker<'b> {
     /// `MetaPicker<'b>`. zenpredict 0.2.0+ made Model own its
     /// reference-data rather than carry a lifetime parameter.
     pub fn new(model: &'b Model) -> Self {
+        let family_at_output = model
+            .metadata()
+            .get_utf8(FAMILY_ORDER_KEY)
+            .ok()
+            .and_then(parse_family_csv)
+            .filter(|v| v.len() == model.n_outputs());
         Self {
             predictor: Predictor::new(model),
+            family_at_output,
         }
     }
 
@@ -256,7 +282,17 @@ impl<'b> MetaPicker<'b> {
         if !allowed.any() {
             return Ok(None);
         }
-        let mask = AllowedMask::new(allowed.as_slice());
+        // Build the mask in the bake's output order — *not*
+        // `allowed.as_slice()`. The bake may cover a subset of
+        // [`CodecFamily::ALL`] in any order, so the i-th bake output
+        // doesn't necessarily map to the i-th `AllowedFamilies` slot.
+        let order: &[CodecFamily] = self
+            .family_at_output
+            .as_deref()
+            .unwrap_or(&CodecFamily::ALL[..]);
+        let bake_mask: alloc::vec::Vec<bool> =
+            order.iter().map(|f| allowed.is_allowed(*f)).collect();
+        let mask = AllowedMask::new(&bake_mask);
         let pick = self
             .predictor
             .argmin_masked(
@@ -266,16 +302,87 @@ impl<'b> MetaPicker<'b> {
                 None::<&ArgminOffsets>,
             )
             .map_err(MetaPickerError::Predict)?;
-        Ok(pick.map(|idx| CodecFamily::ALL[idx]))
+        Ok(pick.map(|idx| order[idx]))
     }
 
-    /// Read the [`FAMILY_ORDER_KEY`] (`zenpicker.family_order`)
-    /// metadata key from the bake and confirm it matches
-    /// [`ALL_LABELS_CSV`]. Returns `Ok(())` if the order matches,
-    /// `Err` on mismatch (caller should refuse to use the picker —
-    /// the bake was made against a different enum layout).
+    /// Pick under a runtime size/speed tradeoff.
     ///
-    /// Best practice: call once at startup, fail loudly on mismatch.
+    /// `predicted_encode_ms_per_family` is a [`CodecFamily::COUNT`]-
+    /// sized table of caller-provided per-family encode-time
+    /// estimates **at the source's resolution** (typically computed
+    /// from `α + β·MPx` models calibrated from a sweep). The caller's
+    /// `bytes_per_ms` weight expresses willingness to pay file-size
+    /// for encode time:
+    ///
+    /// - `0.0` → pure size-optimal (equivalent to [`Self::pick`])
+    /// - `1.0` → 1 ms saved is worth 1 byte (almost always
+    ///   size-optimal in practice)
+    /// - `100.0` → 1 ms saved is worth 100 bytes (typical for
+    ///   client-side encodes where time is precious)
+    /// - `f32::INFINITY` → pure time-optimal (always picks the
+    ///   fastest family in the allowed set)
+    ///
+    /// Internally this builds an [`ArgminOffsets`] in linear-byte
+    /// space (`time_cost = predicted_ms × bytes_per_ms`), maps it
+    /// into the bake's output order, and runs argmin under
+    /// [`ScoreTransform::Exp`] (which converts the trainer's
+    /// log-bytes outputs to the linear-bytes the offset is in).
+    ///
+    /// Behavioural contract: identical to [`Self::pick`] when
+    /// `bytes_per_ms == 0.0`. Different when `> 0`.
+    pub fn pick_with_time_cost(
+        &mut self,
+        features: &[f32],
+        allowed: &AllowedFamilies,
+        predicted_encode_ms_per_family: &[f32; CodecFamily::COUNT],
+        bytes_per_ms: f32,
+    ) -> Result<Option<CodecFamily>, MetaPickerError> {
+        if !allowed.any() {
+            return Ok(None);
+        }
+        let order: &[CodecFamily] = self
+            .family_at_output
+            .as_deref()
+            .unwrap_or(&CodecFamily::ALL[..]);
+
+        let bake_mask: alloc::vec::Vec<bool> =
+            order.iter().map(|f| allowed.is_allowed(*f)).collect();
+        let mask = AllowedMask::new(&bake_mask);
+
+        // Re-index the per-family ms table into the bake's actual
+        // output order. Multiply by bytes_per_ms to produce the
+        // additive byte-equivalent offset.
+        let per_output_offset: alloc::vec::Vec<f32> = order
+            .iter()
+            .map(|f| predicted_encode_ms_per_family[f.index()] * bytes_per_ms)
+            .collect();
+        let offsets = ArgminOffsets {
+            uniform: 0.0,
+            per_output: Some(&per_output_offset),
+        };
+
+        let pick = self
+            .predictor
+            .argmin_masked(features, &mask, ScoreTransform::Exp, Some(&offsets))
+            .map_err(MetaPickerError::Predict)?;
+        Ok(pick.map(|idx| order[idx]))
+    }
+
+    /// Confirm the bake's [`FAMILY_ORDER_KEY`] metadata was present,
+    /// parseable as a CSV of [`CodecFamily`] labels, and length-
+    /// equal to `n_outputs`.
+    ///
+    /// **Subset is OK.** A bake whose order is `"avif,jpeg,jxl,png,webp"`
+    /// (no gif — substrate had no gif data) passes this check. The
+    /// picker's [`pick`](Self::pick) method uses the bake's actual
+    /// order to map output indices to [`CodecFamily`]; callers can
+    /// inspect [`Self::family_at_output`] to learn which families
+    /// the bake can pick.
+    ///
+    /// Returns `Err(MetaPickerError::Metadata(_))` when the metadata
+    /// was missing, malformed, contains an unrecognised label, or
+    /// the parsed length disagrees with `n_outputs`. Best practice:
+    /// call once at startup, fail loudly on mismatch.
     pub fn validate_family_order(&mut self) -> Result<(), MetaPickerError> {
         let raw = self
             .predictor
@@ -284,15 +391,48 @@ impl<'b> MetaPicker<'b> {
             .get_utf8(FAMILY_ORDER_KEY)
             .map_err(|e| MetaPickerError::Metadata(format!("metadata: {:?}", e)))?;
 
-        if raw == ALL_LABELS_CSV {
-            Ok(())
-        } else {
-            Err(MetaPickerError::FamilyOrderMismatch {
-                expected: ALL_LABELS_CSV.to_string(),
-                actual: raw.to_string(),
-            })
+        let parsed = parse_family_csv(raw).ok_or_else(|| {
+            MetaPickerError::Metadata(format!("unparseable family_order CSV: {:?}", raw))
+        })?;
+
+        let n_out = self.predictor.n_outputs();
+        if parsed.len() != n_out {
+            return Err(MetaPickerError::Metadata(format!(
+                "family_order length {} != n_outputs {}",
+                parsed.len(),
+                n_out
+            )));
         }
+        // Cache (replacing whatever was set at construction).
+        self.family_at_output = Some(parsed);
+        Ok(())
     }
+
+    /// The bake's `output_index → CodecFamily` mapping, parsed once
+    /// from the [`FAMILY_ORDER_KEY`] metadata at construction.
+    /// `None` when the metadata was missing or unparseable. Callers
+    /// can use this to enumerate which families this bake can pick
+    /// (e.g. for surfacing UI / honouring caller-supplied
+    /// allow-lists).
+    pub fn family_at_output(&self) -> Option<&[CodecFamily]> {
+        self.family_at_output.as_deref()
+    }
+}
+
+/// Parse `"jpeg,webp,avif,…"` into a vector of [`CodecFamily`].
+/// Returns `None` if any label isn't recognised.
+fn parse_family_csv(csv: &str) -> Option<alloc::vec::Vec<CodecFamily>> {
+    csv.split(',')
+        .map(|tok| match tok.trim() {
+            "jpeg" => Some(CodecFamily::Jpeg),
+            "webp" => Some(CodecFamily::Webp),
+            "jxl" => Some(CodecFamily::Jxl),
+            "avif" => Some(CodecFamily::Avif),
+            "png" => Some(CodecFamily::Png),
+            "gif" => Some(CodecFamily::Gif),
+            _ => None,
+        })
+        .collect::<Option<alloc::vec::Vec<_>>>()
 }
 
 #[derive(Debug)]
@@ -360,6 +500,61 @@ mod tests {
         for (i, fam) in CodecFamily::ALL.iter().enumerate() {
             assert_eq!(fam.index(), i);
         }
+    }
+
+    #[test]
+    fn parse_family_csv_full() {
+        let parsed = parse_family_csv(ALL_LABELS_CSV).unwrap();
+        assert_eq!(parsed, CodecFamily::ALL.to_vec());
+    }
+
+    #[test]
+    fn parse_family_csv_subset_no_gif() {
+        let parsed = parse_family_csv("avif,jpeg,jxl,png,webp").unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                CodecFamily::Avif,
+                CodecFamily::Jpeg,
+                CodecFamily::Jxl,
+                CodecFamily::Png,
+                CodecFamily::Webp,
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_family_csv_unknown_label_returns_none() {
+        assert!(parse_family_csv("jpeg,unknown,webp").is_none());
+    }
+
+    #[test]
+    fn parse_family_csv_handles_whitespace() {
+        let parsed = parse_family_csv(" jpeg , webp ").unwrap();
+        assert_eq!(parsed, vec![CodecFamily::Jpeg, CodecFamily::Webp]);
+    }
+
+    #[test]
+    fn time_cost_table_uses_codec_family_index() {
+        // Assert the synthetic ms-table layout my docstring claims:
+        // index = CodecFamily::ALL position, NOT bake order. The
+        // `pick_with_time_cost` impl re-indexes into bake order
+        // internally — this test fixes the contract.
+        let mut table = [0.0_f32; CodecFamily::COUNT];
+        table[CodecFamily::Jpeg.index()] = 50.0;
+        table[CodecFamily::Webp.index()] = 80.0;
+        table[CodecFamily::Jxl.index()] = 800.0;
+
+        // CodecFamily::Jpeg is index 0, Webp is 1, Jxl is 2.
+        assert_eq!(table[0], 50.0);
+        assert_eq!(table[1], 80.0);
+        assert_eq!(table[2], 800.0);
+
+        // A bake-order CSV like "avif,jpeg,jxl" should re-index to
+        // [Avif, Jpeg, Jxl] — Avif is index 3, so table[3]=0.0.
+        let bake_order = parse_family_csv("avif,jpeg,jxl").unwrap();
+        let reindexed: alloc::vec::Vec<f32> = bake_order.iter().map(|f| table[f.index()]).collect();
+        assert_eq!(reindexed, vec![0.0, 50.0, 800.0]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Single commit on top of the merged three-crate rename. Adds two zenpicker examples and lib.rs additions.

## Files
- \`zenanalyze/zenpicker/examples/i8_vs_f16_agreement.rs\` — measures argmin agreement rate and max raw-output drift between i8-quantized and f16 bakes on the held-out 20% feature set
- \`zenanalyze/zenpicker/examples/load_meta_picker_v0_1.rs\` — loader example
- \`zenanalyze/zenpicker/src/lib.rs\` — 242 lines of additions

## Test plan
- [ ] \`cargo run --release -p zenpicker --example i8_vs_f16_agreement\` against the validation TSV
- [ ] \`cargo run --release -p zenpicker --example load_meta_picker_v0_1\`
- [ ] Confirm lib.rs additions pass tests + clippy