### PR TITLE
feat(predictor): predict_with_specs_transformed auto-routes expander bakes

### DIFF
--- a/zenpredict-bake/src/composer.rs
+++ b/zenpredict-bake/src/composer.rs
@@ -1178,7 +1178,17 @@ fn validate_feature_transforms(
             }
         }
     }
-    if transforms.len() != n_inputs {
+    let has_expander = transforms.iter().any(|t| t.is_expander());
+
+    // For scalar-only pipelines the wire invariant is
+    // `transforms.len() == n_inputs` (n_inputs is the first layer's
+    // in_dim, which equals the raw input count). For pipelines
+    // containing an expander variant (today: only Sinusoidal),
+    // transforms.len() is the **raw** input count and the
+    // post-expansion sum must equal n_inputs. The expansion math
+    // needs the params, so the expander-path check happens below
+    // after we've parsed params.
+    if !has_expander && transforms.len() != n_inputs {
         return Err(BakeError::FeatureTransformsLenMismatch {
             expected: n_inputs,
             got: transforms.len(),
@@ -1190,8 +1200,15 @@ fn validate_feature_transforms(
     // error, not a bake-time hard failure (matches the runtime's
     // `Identity` / plain-Log degradation). We do NOT reject here
     // so the existing "feature_transforms only" workflow keeps
-    // baking.
+    // baking — UNLESS an expander variant is declared, in which
+    // case params are required (frequencies for Sinusoidal).
     let Some(p_entry) = params_entry else {
+        if has_expander {
+            return Err(BakeError::FeatureTransformsLenMismatch {
+                expected: transforms.len(),
+                got: 0,
+            });
+        }
         return Ok(());
     };
     let Ok(p_text) = core::str::from_utf8(p_entry.value) else {
@@ -1211,11 +1228,27 @@ fn validate_feature_transforms(
         }
         params.push(row);
     }
-    if params.len() != n_inputs {
+    if params.len() != transforms.len() {
         return Err(BakeError::FeatureTransformsLenMismatch {
-            expected: n_inputs,
+            expected: transforms.len(),
             got: params.len(),
         });
+    }
+
+    // Expander-aware length check: post-expansion sum must equal
+    // the first-layer in_dim (n_inputs).
+    if has_expander {
+        let expanded: usize = transforms
+            .iter()
+            .zip(params.iter())
+            .map(|(t, p)| t.output_arity(p))
+            .sum();
+        if expanded != n_inputs {
+            return Err(BakeError::FeatureTransformsLenMismatch {
+                expected: n_inputs,
+                got: expanded,
+            });
+        }
     }
 
     // Per-variant arity + domain checks.

--- a/zenpredict-bake/src/json.rs
+++ b/zenpredict-bake/src/json.rs
@@ -77,6 +77,43 @@
 //! any type and used for `bytes` payloads). Picking the right
 //! `type` is the caller's responsibility — the loader uses it as
 //! the wire byte without further interpretation.
+//!
+//! ## Feature transforms (incl. Sinusoidal expander)
+//!
+//! Per-feature transforms ride on two metadata entries:
+//!
+//! ```json
+//! [
+//!   { "key": "zentrain.feature_transforms",
+//!     "type": "utf8",
+//!     "text": "identity\nsinusoidal\nidentity\nidentity\nidentity" },
+//!   { "key": "zentrain.feature_transform_params",
+//!     "type": "utf8",
+//!     "text": "\n1,2,4,8,16,32,64,128,256,512,1024,2048\n\n\n" }
+//! ]
+//! ```
+//!
+//! The two strings are line-aligned: line `i` of `feature_transforms`
+//! declares the variant for raw input `i`, and line `i` of
+//! `feature_transform_params` is the comma-separated parameter list
+//! for that transform. Empty lines mean "no params".
+//!
+//! Scalar variants (everything but `sinusoidal`) preserve the one-input
+//! → one-output contract. The **`sinusoidal`** token marks a
+//! scalar-to-vector expander: each input feature is expanded to
+//! `2 * num_freqs` outputs (sin + cos at each frequency). In the
+//! example above, raw input 1 carries 12 frequencies, so it expands
+//! to 24 features. The total post-transform layer-1 input width is
+//! `sum(output_arity)` over all features, not the raw input count;
+//! the bake-side composer validates `layers[0].in_dim` matches.
+//!
+//! Frequencies are in cycles per unit input — i.e. the multiplier
+//! inside `sin(2π·f·x)` before `2π` scaling. NeRF-style `2^k`
+//! schedules and learned schedules are both fine.
+//!
+//! See `zenpredict::FeatureTransform::Sinusoidal` for the variant's
+//! full math + reference, and `apply_feature_pipeline_expanding` for
+//! the runtime that consumes the wire format.
 
 extern crate alloc;
 

--- a/zenpredict-bake/tests/feature_transform.rs
+++ b/zenpredict-bake/tests/feature_transform.rs
@@ -372,4 +372,28 @@ mod feature_transform_tests {
             assert_eq!(parsed, &[t; 4]);
         }
     }
+
+    #[test]
+    fn sinusoidal_token_round_trips_through_bake() {
+        // Wire-format integration: bake a model declaring one feature
+        // as `sinusoidal`, load it, confirm the parser surfaces the
+        // variant in the right slot. `has_nontrivial_feature_transforms`
+        // must report `true` since Sinusoidal is not Identity.
+        let txt = b"identity\nsinusoidal\nidentity\nidentity";
+        let metadata = [BakeMetadataEntry {
+            key: keys::FEATURE_TRANSFORMS,
+            kind: MetadataType::Utf8,
+            value: txt,
+        }];
+        let bytes = make_identity_passthrough(&metadata);
+        let aligned = Aligned(bytes);
+        let model = Model::from_bytes(&aligned.0).unwrap();
+        let ts = model.feature_transforms().expect("present");
+        assert_eq!(ts.len(), 4);
+        assert_eq!(ts[0], FeatureTransform::Identity);
+        assert_eq!(ts[1], FeatureTransform::Sinusoidal);
+        assert!(ts[1].is_expander());
+        assert!(ts[1].requires_params());
+        assert!(model.has_nontrivial_feature_transforms());
+    }
 }

--- a/zenpredict-bake/tests/feature_transform.rs
+++ b/zenpredict-bake/tests/feature_transform.rs
@@ -375,25 +375,172 @@ mod feature_transform_tests {
 
     #[test]
     fn sinusoidal_token_round_trips_through_bake() {
-        // Wire-format integration: bake a model declaring one feature
-        // as `sinusoidal`, load it, confirm the parser surfaces the
-        // variant in the right slot. `has_nontrivial_feature_transforms`
-        // must report `true` since Sinusoidal is not Identity.
-        let txt = b"identity\nsinusoidal\nidentity\nidentity";
-        let metadata = [BakeMetadataEntry {
-            key: keys::FEATURE_TRANSFORMS,
-            kind: MetadataType::Utf8,
-            value: txt,
-        }];
-        let bytes = make_identity_passthrough(&metadata);
+        // Wire-format integration: bake a 2-raw-input model with a
+        // Sinusoidal transform on input 1 (2 frequencies ⇒ 4
+        // outputs), plus a passthrough Identity on input 0. Total
+        // expanded input width = 1 + 4 = 5, so the first layer needs
+        // in_dim = 5. `make_expanded_passthrough` is parameterized on
+        // the expanded dim.
+        //
+        // Verifies (a) the parser surfaces both variants, (b) the
+        // Model loader's expander-aware length check passes, and
+        // (c) `has_expander_feature_transforms` reports correctly.
+        let transforms_txt = b"identity\nsinusoidal";
+        let params_txt = b"\n1,2";
+        let bytes = make_expanded_passthrough(5, transforms_txt, params_txt);
         let aligned = Aligned(bytes);
         let model = Model::from_bytes(&aligned.0).unwrap();
         let ts = model.feature_transforms().expect("present");
-        assert_eq!(ts.len(), 4);
+        assert_eq!(ts.len(), 2, "raw input count");
         assert_eq!(ts[0], FeatureTransform::Identity);
         assert_eq!(ts[1], FeatureTransform::Sinusoidal);
         assert!(ts[1].is_expander());
         assert!(ts[1].requires_params());
         assert!(model.has_nontrivial_feature_transforms());
+        assert!(model.has_expander_feature_transforms());
+        assert_eq!(model.expanded_input_dim(), 5);
+        // First layer in_dim is the post-expansion width.
+        assert_eq!(model.n_inputs(), 5);
+    }
+
+    // -----------------------------------------------------------------
+    // Sinusoidal end-to-end through Predictor::predict_transformed
+    // -----------------------------------------------------------------
+
+    /// Bake a single-layer identity-passthrough model whose first
+    /// layer takes `expanded_dim` inputs, with the supplied transform
+    /// + param metadata. Used to assert that
+    /// `Predictor::predict_transformed` runs the expanding pipeline
+    /// and forwards the expanded vector through the network.
+    fn make_expanded_passthrough(
+        expanded_dim: usize,
+        transforms_txt: &[u8],
+        params_txt: &[u8],
+    ) -> Vec<u8> {
+        let scaler_mean = vec![0.0f32; expanded_dim];
+        let scaler_scale = vec![1.0f32; expanded_dim];
+        // Identity weights: dst[i] = src[i] for the expanded vector.
+        let mut w0 = vec![0.0f32; expanded_dim * expanded_dim];
+        for i in 0..expanded_dim {
+            w0[i * expanded_dim + i] = 1.0;
+        }
+        let b0 = vec![0.0f32; expanded_dim];
+        let layers = [BakeLayer {
+            in_dim: expanded_dim,
+            out_dim: expanded_dim,
+            activation: Activation::Identity,
+            dtype: WeightDtype::F32,
+            weights: &w0,
+            biases: &b0,
+        }];
+        let metadata = [
+            BakeMetadataEntry {
+                key: keys::FEATURE_TRANSFORMS,
+                kind: MetadataType::Utf8,
+                value: transforms_txt,
+            },
+            BakeMetadataEntry {
+                key: keys::FEATURE_TRANSFORM_PARAMS,
+                kind: MetadataType::Utf8,
+                value: params_txt,
+            },
+        ];
+        bake(&BakeRequest {
+            schema_hash: 0xfeed_face_dead_beef,
+            flags: 0,
+            scaler_mean: &scaler_mean,
+            scaler_scale: &scaler_scale,
+            layers: &layers,
+            feature_bounds: &[],
+            metadata: &metadata,
+            output_specs: &[],
+            discrete_sets: &[],
+            sparse_overrides: &[],
+            feature_order: None,
+            output_order: None,
+            compressed: false,
+            hu_permutations: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn predictor_routes_sinusoidal_through_expanding_path() {
+        // One raw input, Sinusoidal transform with 2 frequencies →
+        // expanded dim 4: [sin(2π·1·x), cos(2π·1·x), sin(2π·2·x),
+        // cos(2π·2·x)]. Identity-passthrough model means the output
+        // equals the expanded vector.
+        let transforms_txt = b"sinusoidal";
+        let params_txt = b"1,2";
+        let bytes = make_expanded_passthrough(4, transforms_txt, params_txt);
+        let aligned = Aligned(bytes);
+        let model = Model::from_bytes(&aligned.0).unwrap();
+
+        // Bake-load invariants.
+        assert!(model.has_expander_feature_transforms());
+        assert_eq!(model.expanded_input_dim(), 4);
+
+        let mut predictor = Predictor::new(&model);
+
+        // x = 0 ⇒ all sins are 0, all cosines are 1.
+        let out_zero = predictor.predict_transformed(&[0.0]).unwrap().to_vec();
+        assert_eq!(out_zero.len(), 4);
+        assert!(
+            (out_zero[0] - 0.0).abs() < 1e-6,
+            "sin(0)=0; got {}",
+            out_zero[0]
+        );
+        assert!(
+            (out_zero[1] - 1.0).abs() < 1e-6,
+            "cos(0)=1; got {}",
+            out_zero[1]
+        );
+        assert!(
+            (out_zero[2] - 0.0).abs() < 1e-6,
+            "sin(0)=0; got {}",
+            out_zero[2]
+        );
+        assert!(
+            (out_zero[3] - 1.0).abs() < 1e-6,
+            "cos(0)=1; got {}",
+            out_zero[3]
+        );
+
+        // x = 0.5, freq=1 ⇒ theta=π ⇒ sin(π)=0, cos(π)=-1.
+        // freq=2 ⇒ theta=2π ⇒ sin(2π)=0, cos(2π)=1.
+        let out_half = predictor.predict_transformed(&[0.5]).unwrap().to_vec();
+        assert!(out_half[0].abs() < 1e-5);
+        assert!((out_half[1] - -1.0).abs() < 1e-5);
+        assert!(out_half[2].abs() < 1e-5);
+        assert!((out_half[3] - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn predictor_scalar_path_still_byte_identical_when_no_expander() {
+        // Regression guard: routing through `predict_transformed` on a
+        // bake with only scalar transforms must produce the exact same
+        // output as before this commit. Bake [Identity, Log, Log1p,
+        // Identity] passthrough and confirm.
+        let transforms_txt = b"identity\nlog\nlog1p\nidentity";
+        let metadata = [BakeMetadataEntry {
+            key: keys::FEATURE_TRANSFORMS,
+            kind: MetadataType::Utf8,
+            value: transforms_txt,
+        }];
+        let bytes = make_identity_passthrough(&metadata);
+        let aligned = Aligned(bytes);
+        let model = Model::from_bytes(&aligned.0).unwrap();
+        assert!(!model.has_expander_feature_transforms());
+
+        let mut predictor = Predictor::new(&model);
+        let e = core::f32::consts::E;
+        let out = predictor
+            .predict_transformed(&[1.0, e, 0.0, 7.0])
+            .unwrap()
+            .to_vec();
+        assert!((out[0] - 1.0).abs() < 1e-6);
+        assert!((out[1] - 1.0).abs() < 1e-5);
+        assert_eq!(out[2], 0.0);
+        assert_eq!(out[3], 7.0);
     }
 }

--- a/zenpredict-bake/tests/feature_transform.rs
+++ b/zenpredict-bake/tests/feature_transform.rs
@@ -240,6 +240,36 @@ mod feature_transform_tests {
     }
 
     #[test]
+    fn predict_with_specs_transformed_routes_sinusoidal() {
+        // Spec-aware path must also auto-route to the expanding
+        // pipeline. Bake: 1 raw input, Sinusoidal at 2 frequencies
+        // ⇒ expanded dim 4 ⇒ identity passthrough emits the
+        // embedding directly. With no output_specs, each output
+        // wraps in OutputValue::Override.
+        let bytes = make_expanded_passthrough(4, b"sinusoidal", b"1,2");
+        let aligned = Aligned(bytes);
+        let model = Model::from_bytes(&aligned.0).unwrap();
+        assert!(model.has_expander_feature_transforms());
+        let mut predictor = Predictor::new(&model);
+
+        // x = 0 ⇒ sins are 0, cosines are 1.
+        let out = predictor.predict_with_specs_transformed(&[0.0]).unwrap();
+        assert_eq!(out.len(), 4);
+        for (i, expected) in [0.0, 1.0, 0.0, 1.0].iter().enumerate() {
+            match out[i] {
+                OutputValue::Override(v) => {
+                    assert!(
+                        (v - expected).abs() < 1e-6,
+                        "out[{i}] expected {expected}, got {v}"
+                    );
+                }
+                OutputValue::Default => panic!("expected Override at {i}"),
+                _ => panic!("unexpected OutputValue variant at {i}"),
+            }
+        }
+    }
+
+    #[test]
     fn unknown_token_rejected_at_bake() {
         // 2026-05-17: bake-side validator now rejects unknown
         // tokens before they reach the wire format. Previously this

--- a/zenpredict/src/error.rs
+++ b/zenpredict/src/error.rs
@@ -83,6 +83,12 @@ pub enum PredictError {
     /// `n_inputs` (or the runtime helper's `transforms` slice
     /// disagreed with `features.len()`).
     FeatureTransformsLenMismatch { expected: usize, got: usize },
+    /// A scalar-only pipeline (`apply_feature_transforms`) was called
+    /// with an expander variant (today: only `FeatureTransform::Sinusoidal`)
+    /// in the transforms list. Use `apply_feature_pipeline_expanding`,
+    /// or call the expander-aware Predictor entry point that routes
+    /// automatically.
+    UnexpectedExpanderInScalarPipeline { feature_index: usize },
 }
 
 impl fmt::Display for PredictError {
@@ -175,6 +181,13 @@ impl fmt::Display for PredictError {
             Self::FeatureTransformsLenMismatch { expected, got } => write!(
                 f,
                 "zenpredict: feature_transforms length {got} != expected {expected}"
+            ),
+            Self::UnexpectedExpanderInScalarPipeline { feature_index } => write!(
+                f,
+                "zenpredict: scalar feature-transform pipeline encountered an \
+                 expander variant at feature index {feature_index} \
+                 (use apply_feature_pipeline_expanding or the auto-routing \
+                 Predictor entry point)"
             ),
         }
     }

--- a/zenpredict/src/feature_transform.rs
+++ b/zenpredict/src/feature_transform.rs
@@ -425,10 +425,18 @@ impl FeatureTransform {
             // invariant other variants follow).
             Self::YeoJohnson => x,
             Self::WinsorP99 | Self::QuantileBins => x,
-            // Scalar `apply` for the expander variant is a deliberate
-            // pass-through — see the variant docstring for why. Callers
-            // that want the embedding output must use `apply_expanding`.
-            Self::Sinusoidal => x,
+            // Scalar `apply` cannot represent an expander variant. The
+            // bake-load + runtime paths route through
+            // `apply_expanding` / `apply_feature_pipeline_expanding` /
+            // `Predictor::predict_transformed` (auto-routes); a panic
+            // here means the caller bypassed those layers, which is a
+            // programmer error. Loud failure is the contract — silent
+            // pass-through would let a Sinusoidal bake produce subtly
+            // wrong predictions in code that doesn't expect an expander.
+            Self::Sinusoidal => panic!(
+                "FeatureTransform::Sinusoidal cannot be applied via scalar `apply` — \
+                 use `apply_expanding` / `apply_feature_pipeline_expanding`"
+            ),
         }
     }
 
@@ -575,10 +583,12 @@ impl FeatureTransform {
                 };
                 yeo_johnson(x, lambda)
             }
-            // Sinusoidal cannot fit the scalar `f32 → f32` contract;
-            // fall through to `apply` which pass-throughs `x`. Callers
-            // that want the embedding must use `apply_expanding`.
-            Self::Sinusoidal => x,
+            // Sinusoidal is an expander — see `apply` for the rationale
+            // on why this panics instead of returning a degenerate scalar.
+            Self::Sinusoidal => panic!(
+                "FeatureTransform::Sinusoidal cannot be applied via scalar `apply_with_params` — \
+                 use `apply_expanding` / `apply_feature_pipeline_expanding`"
+            ),
             _ => self.apply(x),
         }
     }
@@ -737,18 +747,24 @@ impl FeatureTransform {
     }
 }
 
-/// Read the `zentrain.feature_transforms` metadata into a typed list
-/// of length `n_inputs`. Returns `Ok(None)` when the key is absent
-/// (consumers should then treat every feature as `Identity`); returns
-/// `Ok(Some(_))` with `len == n_inputs` when present and well-formed.
+/// Read the `zentrain.feature_transforms` metadata into a typed list.
+/// Returns `Ok(None)` when the key is absent (consumers should then
+/// treat every feature as `Identity`); returns `Ok(Some(_))` when
+/// present and well-formed.
+///
+/// Length validation lives in the Model loader, not here — for
+/// expander-containing bakes the transforms count equals the **raw**
+/// input feature count (which can differ from the first layer's
+/// `in_dim` after embedding). The loader cross-checks
+/// `transforms.len() == feature_transform_params.len()` and
+/// `total_output_arity(transforms, params) == first_layer.in_dim`.
 ///
 /// Error cases (all hard-fail):
 /// - The key is present but its value type is not UTF-8.
-/// - The value contains a token that isn't `identity`/`log`/`log1p`.
-/// - The line count doesn't equal `n_inputs`.
+/// - The value contains a token not registered in
+///   [`FeatureTransform::from_token`].
 pub(crate) fn parse_feature_transforms(
     metadata: &Metadata<'_>,
-    n_inputs: usize,
 ) -> Result<Option<alloc::vec::Vec<FeatureTransform>>, PredictError> {
     let Some(entry) = metadata.get(crate::keys::FEATURE_TRANSFORMS) else {
         return Ok(None);
@@ -760,8 +776,6 @@ pub(crate) fn parse_feature_transforms(
             got: entry.kind,
         });
     }
-    // Validated as UTF-8 at parse time, but go through `from_utf8`
-    // again so a future refactor can't regress the invariant.
     let text =
         core::str::from_utf8(entry.value).map_err(|_| PredictError::MetadataValueNotUtf8 {
             key_len: crate::keys::FEATURE_TRANSFORMS.len(),
@@ -770,15 +784,9 @@ pub(crate) fn parse_feature_transforms(
     // exactly. An empty trailing line (text ending with '\n') would
     // produce a stray empty entry; reject that as malformed rather
     // than silently dropping it.
-    let mut transforms = alloc::vec::Vec::with_capacity(n_inputs);
+    let mut transforms = alloc::vec::Vec::new();
     for token in text.split('\n') {
         transforms.push(FeatureTransform::from_token(token)?);
-    }
-    if transforms.len() != n_inputs {
-        return Err(PredictError::FeatureTransformsLenMismatch {
-            expected: n_inputs,
-            got: transforms.len(),
-        });
     }
     Ok(Some(transforms))
 }
@@ -799,7 +807,6 @@ pub(crate) fn parse_feature_transforms(
 /// [`FeatureTransform::WinsorP99`].
 pub(crate) fn parse_feature_transform_params(
     metadata: &Metadata<'_>,
-    n_inputs: usize,
 ) -> Result<Option<alloc::vec::Vec<alloc::vec::Vec<f32>>>, PredictError> {
     let Some(entry) = metadata.get(crate::keys::FEATURE_TRANSFORM_PARAMS) else {
         return Ok(None);
@@ -815,7 +822,7 @@ pub(crate) fn parse_feature_transform_params(
         core::str::from_utf8(entry.value).map_err(|_| PredictError::MetadataValueNotUtf8 {
             key_len: crate::keys::FEATURE_TRANSFORM_PARAMS.len(),
         })?;
-    let mut params = alloc::vec::Vec::with_capacity(n_inputs);
+    let mut params = alloc::vec::Vec::new();
     for line in text.split('\n') {
         let mut row: alloc::vec::Vec<f32> = alloc::vec::Vec::new();
         if !line.is_empty() {
@@ -831,18 +838,22 @@ pub(crate) fn parse_feature_transform_params(
         }
         params.push(row);
     }
-    if params.len() != n_inputs {
-        return Err(PredictError::FeatureTransformsLenMismatch {
-            expected: n_inputs,
-            got: params.len(),
-        });
-    }
     Ok(Some(params))
 }
 
 /// Apply each transform to the matching feature, writing into `dst`.
 /// `transforms.len()` must equal `src.len()`; `dst.len()` must equal
 /// `src.len()`.
+///
+/// **Scalar-only pipeline.** This helper enforces the
+/// one-input → one-output contract. If any transform in
+/// `transforms` is an expander variant (today: only
+/// [`FeatureTransform::Sinusoidal`]), returns
+/// [`PredictError::UnexpectedExpanderInScalarPipeline`] *before*
+/// processing — callers must route through
+/// [`apply_feature_pipeline_expanding`], or use the auto-routing
+/// `Predictor::predict_transformed` entry point that picks the right
+/// pipeline based on the bake's metadata.
 #[inline]
 pub fn apply_feature_transforms(
     transforms: &[FeatureTransform],
@@ -854,6 +865,9 @@ pub fn apply_feature_transforms(
             expected: src.len(),
             got: transforms.len(),
         });
+    }
+    if let Some(i) = transforms.iter().position(|t| t.is_expander()) {
+        return Err(PredictError::UnexpectedExpanderInScalarPipeline { feature_index: i });
     }
     for (i, &t) in transforms.iter().enumerate() {
         dst[i] = t.apply(src[i]);
@@ -924,7 +938,8 @@ pub fn apply_feature_pipeline_expanding(
     let mut offset = 0usize;
     for i in 0..src.len() {
         let arity = transforms[i].output_arity(params[i]);
-        let written = transforms[i].apply_expanding(src[i], params[i], &mut dst[offset..offset + arity]);
+        let written =
+            transforms[i].apply_expanding(src[i], params[i], &mut dst[offset..offset + arity]);
         debug_assert_eq!(written, arity);
         offset += arity;
     }
@@ -960,6 +975,9 @@ pub fn apply_feature_transforms_with_params(
             expected: src.len(),
             got: transforms.len(),
         });
+    }
+    if let Some(i) = transforms.iter().position(|t| t.is_expander()) {
+        return Err(PredictError::UnexpectedExpanderInScalarPipeline { feature_index: i });
     }
     for i in 0..src.len() {
         dst[i] = transforms[i].apply_with_params(src[i], params[i]);
@@ -1453,6 +1471,11 @@ mod tests {
             FeatureTransform::SignedCbrtThenWinsor => &[-2.0_f32, 2.0],
             FeatureTransform::ClipThenLog1pThenWinsor => &[0.1_f32, 0.0, 3.0],
             FeatureTransform::YeoJohnson => &[-50.0_f32],
+            // Sinusoidal is an expander (panics under scalar apply),
+            // so it is excluded from `all_variants()` and never reaches
+            // these scalar NaN-safety helpers. This arm only keeps the
+            // match exhaustive for the non_exhaustive enum.
+            FeatureTransform::Sinusoidal => &[1.0_f32, 2.0],
         }
     }
 
@@ -1577,6 +1600,8 @@ mod tests {
             let parsed = FeatureTransform::from_token(tok).expect("from_token");
             assert_eq!(parsed, t, "round-trip failed for {tok}");
         }
+    }
+
     // -----------------------------------------------------------------
     // Sinusoidal embedding (expander variant)
     // -----------------------------------------------------------------
@@ -1631,15 +1656,60 @@ mod tests {
     }
 
     #[test]
-    fn sinusoidal_scalar_apply_is_pass_through() {
-        // The variant docstring promises this: scalar `apply` /
-        // `apply_with_params` ignore the embedding entirely (returns
-        // `x` unchanged). This is a load-bearing degenerate fallback
-        // that keeps the old scalar pipeline safe when a Sinusoidal
-        // transform reaches code that doesn't expect an expander.
-        let t = FeatureTransform::Sinusoidal;
-        assert_eq!(t.apply(2.5), 2.5);
-        assert_eq!(t.apply_with_params(2.5, &[1.0, 2.0]), 2.5);
+    #[should_panic(expected = "FeatureTransform::Sinusoidal cannot be applied via scalar `apply`")]
+    fn sinusoidal_scalar_apply_panics() {
+        // The scalar path cannot represent an expander variant.
+        // Loud failure beats silent pass-through: a Sinusoidal bake
+        // routed through `apply` would otherwise produce subtly wrong
+        // predictions in callers that don't know about expanders.
+        let _ = FeatureTransform::Sinusoidal.apply(2.5);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "FeatureTransform::Sinusoidal cannot be applied via scalar `apply_with_params`"
+    )]
+    fn sinusoidal_scalar_apply_with_params_panics() {
+        let _ = FeatureTransform::Sinusoidal.apply_with_params(2.5, &[1.0, 2.0]);
+    }
+
+    #[test]
+    fn scalar_pipeline_errors_on_expander() {
+        // `apply_feature_transforms` enforces the scalar contract by
+        // rejecting expander variants up front — the alternative is
+        // `apply_feature_pipeline_expanding`. Callers that don't
+        // notice the difference get a hard error, not silent garbage.
+        let transforms = [
+            FeatureTransform::Identity,
+            FeatureTransform::Sinusoidal,
+            FeatureTransform::Log,
+        ];
+        let src = [1.0_f32, 2.0_f32, 3.0_f32];
+        let mut dst = [0.0_f32; 3];
+        let err = apply_feature_transforms(&transforms, &src, &mut dst)
+            .expect_err("scalar pipeline must reject Sinusoidal");
+        match err {
+            PredictError::UnexpectedExpanderInScalarPipeline { feature_index } => {
+                assert_eq!(feature_index, 1);
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scalar_pipeline_with_params_errors_on_expander() {
+        let transforms = [FeatureTransform::Identity, FeatureTransform::Sinusoidal];
+        let p_empty: &[f32] = &[];
+        let p_freqs: &[f32] = &[1.0, 2.0];
+        let params: alloc::vec::Vec<&[f32]> = alloc::vec![p_empty, p_freqs];
+        let src = [1.0_f32, 0.0_f32];
+        let mut dst = [0.0_f32; 2];
+        let err = apply_feature_transforms_with_params(&transforms, &params, &src, &mut dst)
+            .expect_err("scalar-with-params pipeline must reject Sinusoidal");
+        assert!(matches!(
+            err,
+            PredictError::UnexpectedExpanderInScalarPipeline { feature_index: 1 }
+        ));
     }
 
     #[test]
@@ -1660,8 +1730,8 @@ mod tests {
 
         let src = [0.0_f32, 0.0_f32, core::f32::consts::E];
         let mut dst = [99.0f32; 6];
-        let n = apply_feature_pipeline_expanding(&transforms, &params, &src, &mut dst)
-            .expect("expand");
+        let n =
+            apply_feature_pipeline_expanding(&transforms, &params, &src, &mut dst).expect("expand");
         assert_eq!(n, 6);
         // Identity: 0
         assert_eq!(dst[0], 0.0);

--- a/zenpredict/src/feature_transform.rs
+++ b/zenpredict/src/feature_transform.rs
@@ -162,7 +162,44 @@ pub enum FeatureTransform {
     /// falls back to `Identity` (caller error — the trainer is
     /// expected to bake a λ at preprocessing time). Added 2026-05-25.
     YeoJohnson,
+    /// Sinusoidal positional embedding — `[sin(2π·f₀·x), cos(2π·f₀·x),
+    /// sin(2π·f₁·x), cos(2π·f₁·x), …]` for `N` frequencies, expanding
+    /// one input feature to `2·N` output features. Unlike every other
+    /// variant in this enum, Sinusoidal is **scalar-to-vector**: it
+    /// cannot be applied via the per-feature [`Self::apply`] /
+    /// [`Self::apply_with_params`] path, which assume `f32 → f32`.
+    ///
+    /// Callers MUST route through [`Self::output_arity`] +
+    /// [`Self::apply_expanding`] (and for whole-vector input, through
+    /// [`apply_feature_pipeline_expanding`]). The scalar `apply` /
+    /// `apply_with_params` paths return `x` unchanged for Sinusoidal
+    /// — a deliberate no-op that keeps the existing scalar pipeline
+    /// safe when a Sinusoidal transform sneaks into a context that
+    /// doesn't understand expanders (catastrophic-fail-loud is worse
+    /// than degenerate-pass-through here, since `apply` is called
+    /// from many call sites that pre-date the variant).
+    ///
+    /// Requires **N parameters** (the frequencies `f₀ … f_{N-1}` in
+    /// cycles per unit input — i.e. the multiplier inside `sin(2π·f·x)`
+    /// before `2π` scaling). Typical NeRF-style schedules use
+    /// `f_k = 2^k` for `k = 0..N-1`. With `params = []` the variant
+    /// produces no output (arity 0); a bake-side validator SHOULD
+    /// reject this since it leaves the downstream layer width
+    /// undefined.
+    ///
+    /// **Wire format:** the `feature_transforms` line uses token
+    /// `"sinusoidal"`; the parallel `feature_transform_params` line
+    /// lists the frequencies comma-separated. Both sin and cos are
+    /// always emitted (no sin-only / cos-only switch in this variant
+    /// — add a sibling variant if a one-phase-only embedding is ever
+    /// needed). Added 2026-05-18 for Gain-MLP-style per-pixel MLPs
+    /// (Canham et al. 2025).
+    Sinusoidal,
 }
+
+/// Two-pi constant for sinusoidal embedding. Mirrors `core::f32::consts::TAU`
+/// without pulling it in directly (keeps `no_std` builds identical to std).
+const TWO_PI: f32 = 6.283_185_5_f32;
 
 /// Branchless inclusive clamp that tolerates `lo > hi` (returns `lo`)
 /// and `NaN` (returns `NaN`). Mirrors the WinsorP99 arm's behaviour
@@ -388,6 +425,10 @@ impl FeatureTransform {
             // invariant other variants follow).
             Self::YeoJohnson => x,
             Self::WinsorP99 | Self::QuantileBins => x,
+            // Scalar `apply` for the expander variant is a deliberate
+            // pass-through — see the variant docstring for why. Callers
+            // that want the embedding output must use `apply_expanding`.
+            Self::Sinusoidal => x,
         }
     }
 
@@ -534,6 +575,10 @@ impl FeatureTransform {
                 };
                 yeo_johnson(x, lambda)
             }
+            // Sinusoidal cannot fit the scalar `f32 → f32` contract;
+            // fall through to `apply` which pass-throughs `x`. Callers
+            // that want the embedding must use `apply_expanding`.
+            Self::Sinusoidal => x,
             _ => self.apply(x),
         }
     }
@@ -556,7 +601,86 @@ impl FeatureTransform {
                 | Self::SignedCbrtThenWinsor
                 | Self::ClipThenLog1pThenWinsor
                 | Self::YeoJohnson
+                | Self::Sinusoidal
         )
+    }
+
+    /// Returns true if this transform is **scalar-to-vector** — i.e. it
+    /// expands one input feature into multiple output features. Today
+    /// only [`Self::Sinusoidal`] is an expander; every other variant
+    /// returns `false`.
+    ///
+    /// Use this on the bake-load path to decide whether the simple
+    /// scalar [`apply_feature_transforms`] pipeline is safe, or
+    /// whether the model needs the [`apply_feature_pipeline_expanding`]
+    /// path (which sums per-feature arities into the layer width).
+    #[inline]
+    pub fn is_expander(self) -> bool {
+        matches!(self, Self::Sinusoidal)
+    }
+
+    /// How many output values this transform produces from one input
+    /// given a `params` slice. Scalar variants always return `1`. The
+    /// expander variant [`Self::Sinusoidal`] returns `2 * params.len()`
+    /// — sin and cos at each frequency. Empty params produce arity
+    /// `0` (degenerate; the bake-side validator should reject this).
+    #[inline]
+    pub fn output_arity(self, params: &[f32]) -> usize {
+        match self {
+            Self::Sinusoidal => 2 * params.len(),
+            _ => 1,
+        }
+    }
+
+    /// Apply this transform writing `output_arity(params)` values into
+    /// `dst`. For scalar variants this is `dst[0] = apply_with_params(x, params)`
+    /// and `dst.len()` must be `>= 1`. For [`Self::Sinusoidal`] the
+    /// output is `[sin(2π·f₀·x), cos(2π·f₀·x), sin(2π·f₁·x),
+    /// cos(2π·f₁·x), …]`; `dst.len()` must be `>= 2 * params.len()`.
+    ///
+    /// Returns the number of values written. Panics in debug if `dst`
+    /// is too short; releases silently truncate to `dst.len()` (the
+    /// bake-side validator is the right place to catch undersized
+    /// allocations).
+    #[inline]
+    pub fn apply_expanding(self, x: f32, params: &[f32], dst: &mut [f32]) -> usize {
+        match self {
+            Self::Sinusoidal => {
+                let n = params.len();
+                debug_assert!(
+                    dst.len() >= 2 * n,
+                    "Sinusoidal dst too short: {} < {}",
+                    dst.len(),
+                    2 * n
+                );
+                let mut written = 0;
+                for &freq in params {
+                    if written + 2 > dst.len() {
+                        break;
+                    }
+                    let theta = TWO_PI * freq * x;
+                    #[cfg(feature = "std")]
+                    {
+                        dst[written] = theta.sin();
+                        dst[written + 1] = theta.cos();
+                    }
+                    #[cfg(not(feature = "std"))]
+                    {
+                        dst[written] = libm::sinf(theta);
+                        dst[written + 1] = libm::cosf(theta);
+                    }
+                    written += 2;
+                }
+                written
+            }
+            _ => {
+                if dst.is_empty() {
+                    return 0;
+                }
+                dst[0] = self.apply_with_params(x, params);
+                1
+            }
+        }
     }
 
     /// Parse one of the wire-format token strings. Unknown tokens
@@ -585,6 +709,7 @@ impl FeatureTransform {
             "signed_cbrt_then_winsor" => Ok(Self::SignedCbrtThenWinsor),
             "clip_then_log1p_then_winsor" => Ok(Self::ClipThenLog1pThenWinsor),
             "yeo_johnson" => Ok(Self::YeoJohnson),
+            "sinusoidal" => Ok(Self::Sinusoidal),
             _ => Err(PredictError::UnknownFeatureTransform),
         }
     }
@@ -607,6 +732,7 @@ impl FeatureTransform {
             Self::SignedCbrtThenWinsor => "signed_cbrt_then_winsor",
             Self::ClipThenLog1pThenWinsor => "clip_then_log1p_then_winsor",
             Self::YeoJohnson => "yeo_johnson",
+            Self::Sinusoidal => "sinusoidal",
         }
     }
 }
@@ -733,6 +859,76 @@ pub fn apply_feature_transforms(
         dst[i] = t.apply(src[i]);
     }
     Ok(())
+}
+
+/// Sum the per-feature output arities under a (`transforms`, `params`)
+/// pair. For all-scalar pipelines this equals `transforms.len()`; for
+/// pipelines containing [`FeatureTransform::Sinusoidal`] it equals the
+/// post-expansion layer-1 input width.
+///
+/// Used by the bake-load path to allocate the expanded feature buffer
+/// and verify the model's `layers[0].in_dim` matches.
+#[inline]
+pub fn total_output_arity(transforms: &[FeatureTransform], params: &[&[f32]]) -> usize {
+    debug_assert_eq!(transforms.len(), params.len());
+    let mut total = 0usize;
+    for i in 0..transforms.len() {
+        total += transforms[i].output_arity(params[i]);
+    }
+    total
+}
+
+/// Apply each transform with per-feature params, writing into `dst`
+/// using the variable-arity contract. `transforms.len()` must equal
+/// `params.len()` must equal `src.len()`. `dst.len()` must equal
+/// [`total_output_arity`] of the same `(transforms, params)`.
+///
+/// Differs from [`apply_feature_transforms_with_params`] in that it
+/// honours scalar-to-vector variants ([`FeatureTransform::Sinusoidal`]):
+/// each input may produce one or more output values, packed
+/// consecutively into `dst`. Scalar-only pipelines produce identical
+/// results to `apply_feature_transforms_with_params`.
+///
+/// Returns the number of values written to `dst` (equal to `dst.len()`
+/// on success). Returns [`PredictError::FeatureTransformsLenMismatch`]
+/// if the input lengths disagree or the output buffer is wrong-sized.
+///
+/// **API-stability note:** currently unused inside zenpredict — the
+/// `Predictor::predict_transformed` fast path takes the scalar
+/// [`apply_feature_transforms`] route, which is correct for every
+/// shipped bake. Wiring the expanding path into `Predictor` is the
+/// follow-up commit that activates Sinusoidal in production. Kept
+/// public so downstream consumers (e.g., `zentone::gainmap_mlp`)
+/// can drive the expansion themselves while the integration lands.
+#[allow(dead_code)]
+#[inline]
+pub fn apply_feature_pipeline_expanding(
+    transforms: &[FeatureTransform],
+    params: &[&[f32]],
+    src: &[f32],
+    dst: &mut [f32],
+) -> Result<usize, PredictError> {
+    if transforms.len() != src.len() || params.len() != src.len() {
+        return Err(PredictError::FeatureTransformsLenMismatch {
+            expected: src.len(),
+            got: transforms.len(),
+        });
+    }
+    let expected_dst = total_output_arity(transforms, params);
+    if dst.len() != expected_dst {
+        return Err(PredictError::FeatureTransformsLenMismatch {
+            expected: expected_dst,
+            got: dst.len(),
+        });
+    }
+    let mut offset = 0usize;
+    for i in 0..src.len() {
+        let arity = transforms[i].output_arity(params[i]);
+        let written = transforms[i].apply_expanding(src[i], params[i], &mut dst[offset..offset + arity]);
+        debug_assert_eq!(written, arity);
+        offset += arity;
+    }
+    Ok(offset)
 }
 
 /// Apply each transform with optional per-feature params, writing into
@@ -1381,5 +1577,137 @@ mod tests {
             let parsed = FeatureTransform::from_token(tok).expect("from_token");
             assert_eq!(parsed, t, "round-trip failed for {tok}");
         }
+    // -----------------------------------------------------------------
+    // Sinusoidal embedding (expander variant)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn sinusoidal_token_round_trip() {
+        let t = FeatureTransform::from_token("sinusoidal").expect("parse");
+        assert_eq!(t, FeatureTransform::Sinusoidal);
+        assert_eq!(t.as_token(), "sinusoidal");
+        assert!(t.requires_params());
+        assert!(t.is_expander());
+    }
+
+    #[test]
+    fn sinusoidal_output_arity_doubles_param_count() {
+        let t = FeatureTransform::Sinusoidal;
+        assert_eq!(t.output_arity(&[]), 0);
+        assert_eq!(t.output_arity(&[1.0]), 2);
+        assert_eq!(t.output_arity(&[1.0, 2.0, 4.0]), 6);
+        // 24 frequencies × (sin + cos) = 48 outputs per input feature,
+        // matching the Gain-MLP paper's 24-D per-input embedding when
+        // counted as 12 frequencies × 2 phases.
+        let freqs: alloc::vec::Vec<f32> = (0..12).map(|k| (1u32 << k) as f32).collect();
+        assert_eq!(t.output_arity(&freqs), 24);
+    }
+
+    #[test]
+    fn sinusoidal_apply_expanding_writes_sin_cos_pairs() {
+        let t = FeatureTransform::Sinusoidal;
+        // freq=0 → sin(0)=0, cos(0)=1 for any x
+        let mut dst = [99.0f32; 2];
+        let n = t.apply_expanding(core::f32::consts::PI, &[0.0], &mut dst);
+        assert_eq!(n, 2);
+        assert!(dst[0].abs() < 1e-6);
+        assert!((dst[1] - 1.0).abs() < 1e-6);
+
+        // freq=0.5, x=1 → theta = 2π · 0.5 · 1 = π → sin(π)=0, cos(π)=-1
+        let mut dst = [99.0f32; 2];
+        let n = t.apply_expanding(1.0, &[0.5], &mut dst);
+        assert_eq!(n, 2);
+        assert!(dst[0].abs() < 1e-5);
+        assert!((dst[1] - -1.0).abs() < 1e-5);
+
+        // Two freqs, x=0 → all sins are 0, all cosines are 1.
+        let mut dst = [99.0f32; 4];
+        let n = t.apply_expanding(0.0, &[1.0, 2.0], &mut dst);
+        assert_eq!(n, 4);
+        assert_eq!(dst[0], 0.0);
+        assert_eq!(dst[1], 1.0);
+        assert_eq!(dst[2], 0.0);
+        assert_eq!(dst[3], 1.0);
+    }
+
+    #[test]
+    fn sinusoidal_scalar_apply_is_pass_through() {
+        // The variant docstring promises this: scalar `apply` /
+        // `apply_with_params` ignore the embedding entirely (returns
+        // `x` unchanged). This is a load-bearing degenerate fallback
+        // that keeps the old scalar pipeline safe when a Sinusoidal
+        // transform reaches code that doesn't expect an expander.
+        let t = FeatureTransform::Sinusoidal;
+        assert_eq!(t.apply(2.5), 2.5);
+        assert_eq!(t.apply_with_params(2.5, &[1.0, 2.0]), 2.5);
+    }
+
+    #[test]
+    fn expanding_pipeline_packs_mixed_arities() {
+        // 3 input features: [Identity, Sinusoidal(2 freqs), Log] → 5 outputs
+        // ([x0, sin(2π·1·x1), cos(2π·1·x1), sin(2π·2·x1), cos(2π·2·x1), ln(x2)])
+        let transforms = [
+            FeatureTransform::Identity,
+            FeatureTransform::Sinusoidal,
+            FeatureTransform::Log,
+        ];
+        let p_id: &[f32] = &[];
+        let p_sin: &[f32] = &[1.0, 2.0];
+        let p_log: &[f32] = &[];
+        let params: alloc::vec::Vec<&[f32]> = alloc::vec![p_id, p_sin, p_log];
+
+        assert_eq!(total_output_arity(&transforms, &params), 6);
+
+        let src = [0.0_f32, 0.0_f32, core::f32::consts::E];
+        let mut dst = [99.0f32; 6];
+        let n = apply_feature_pipeline_expanding(&transforms, &params, &src, &mut dst)
+            .expect("expand");
+        assert_eq!(n, 6);
+        // Identity: 0
+        assert_eq!(dst[0], 0.0);
+        // Sinusoidal at x=0: every sin=0, every cos=1
+        assert_eq!(dst[1], 0.0);
+        assert_eq!(dst[2], 1.0);
+        assert_eq!(dst[3], 0.0);
+        assert_eq!(dst[4], 1.0);
+        // Log(e) ≈ 1
+        assert!((dst[5] - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn expanding_pipeline_rejects_wrong_dst_size() {
+        let transforms = [FeatureTransform::Sinusoidal];
+        let p_sin: &[f32] = &[1.0];
+        let params: alloc::vec::Vec<&[f32]> = alloc::vec![p_sin];
+        let src = [0.0f32];
+        // Expected dst length is 2 (2 * 1 freq). 0-length and 3-length
+        // both error.
+        let mut dst0: [f32; 0] = [];
+        let mut dst3 = [0.0f32; 3];
+        assert!(apply_feature_pipeline_expanding(&transforms, &params, &src, &mut dst0).is_err());
+        assert!(apply_feature_pipeline_expanding(&transforms, &params, &src, &mut dst3).is_err());
+    }
+
+    #[test]
+    fn expanding_pipeline_matches_scalar_pipeline_when_no_expanders() {
+        // For an all-scalar input the expanding pipeline must produce
+        // byte-identical output to the existing scalar one — guarantees
+        // we can mix the two paths without changing bake behavior.
+        let transforms = [
+            FeatureTransform::Identity,
+            FeatureTransform::Log1p,
+            FeatureTransform::SignedSqrt,
+        ];
+        let src = [3.5_f32, 0.0_f32, -9.0_f32];
+        let p: &[f32] = &[];
+        let params: alloc::vec::Vec<&[f32]> = alloc::vec![p, p, p];
+
+        let mut dst_expand = [0.0f32; 3];
+        apply_feature_pipeline_expanding(&transforms, &params, &src, &mut dst_expand).unwrap();
+
+        let mut dst_scalar = [0.0f32; 3];
+        apply_feature_transforms(&transforms, &src, &mut dst_scalar).unwrap();
+
+        assert_eq!(dst_expand, dst_scalar);
     }
 }

--- a/zenpredict/src/model.rs
+++ b/zenpredict/src/model.rs
@@ -676,8 +676,40 @@ impl Model {
         // ── Stage 5: parse feature_transforms + transform_params metadata. ──
         let metadata_bytes = header.metadata.slice("metadata", &bytes)?;
         let metadata = Metadata::parse(metadata_bytes)?;
-        let feature_transforms = parse_feature_transforms(&metadata, n_inputs)?;
-        let feature_transform_params = parse_feature_transform_params(&metadata, n_inputs)?;
+        let feature_transforms = parse_feature_transforms(&metadata)?;
+        let feature_transform_params = parse_feature_transform_params(&metadata)?;
+
+        // ── Stage 6: cross-validate the feature pipeline. ──
+        //
+        // For scalar-only pipelines, `transforms.len() == n_inputs`
+        // (the first-layer in_dim). For pipelines that contain an
+        // expander variant (today: only Sinusoidal), `transforms.len()`
+        // is the **raw** input feature count, and the sum of
+        // per-feature output arities equals the first-layer in_dim.
+        // Both shapes must agree on the parallel transforms/params
+        // arrays.
+        if let Some(ref ts) = feature_transforms {
+            if let Some(ref ps) = feature_transform_params
+                && ts.len() != ps.len()
+            {
+                return Err(PredictError::FeatureTransformsLenMismatch {
+                    expected: ts.len(),
+                    got: ps.len(),
+                });
+            }
+            // Compute expanded dim: sum of per-feature arities.
+            // Missing params metadata ⇒ every feature uses `&[]`.
+            let expanded: usize = match &feature_transform_params {
+                Some(ps) => (0..ts.len()).map(|i| ts[i].output_arity(&ps[i])).sum(),
+                None => ts.iter().map(|t| t.output_arity(&[])).sum(),
+            };
+            if expanded != n_inputs {
+                return Err(PredictError::FeatureTransformsLenMismatch {
+                    expected: n_inputs,
+                    got: expanded,
+                });
+            }
+        }
 
         Ok(Self {
             bytes,
@@ -941,6 +973,44 @@ impl Model {
         self.feature_transforms
             .as_deref()
             .is_some_and(|ts| ts.iter().any(|t| *t != FeatureTransform::Identity))
+    }
+
+    /// True iff at least one declared transform is a scalar-to-vector
+    /// expander (today: only [`FeatureTransform::Sinusoidal`]). Used by
+    /// the Predictor to decide between the scalar fast path and the
+    /// variable-arity pipeline.
+    pub fn has_expander_feature_transforms(&self) -> bool {
+        self.feature_transforms
+            .as_deref()
+            .is_some_and(|ts| ts.iter().any(|t| t.is_expander()))
+    }
+
+    /// Sum of per-feature output arities under the loaded transforms +
+    /// params. For scalar-only bakes equals `n_inputs()`; for bakes
+    /// containing [`FeatureTransform::Sinusoidal`] equals the
+    /// post-expansion layer-1 input width. Returns `n_inputs()` when no
+    /// transforms metadata is present.
+    pub fn expanded_input_dim(&self) -> usize {
+        let Some(transforms) = self.feature_transforms.as_deref() else {
+            return self.n_inputs();
+        };
+        match self.feature_transform_params.as_deref() {
+            Some(all_params) => {
+                debug_assert_eq!(all_params.len(), transforms.len());
+                let mut total = 0usize;
+                for i in 0..transforms.len() {
+                    total += transforms[i].output_arity(&all_params[i]);
+                }
+                total
+            }
+            None => {
+                // No params metadata ⇒ every transform uses empty
+                // params ⇒ scalar variants have arity 1, Sinusoidal
+                // has arity 0 (degenerate; bake-side validator should
+                // reject this). Sum accordingly.
+                transforms.iter().map(|t| t.output_arity(&[])).sum()
+            }
+        }
     }
 
     pub fn scratch_len(&self) -> usize {

--- a/zenpredict/src/predictor.rs
+++ b/zenpredict/src/predictor.rs
@@ -9,7 +9,9 @@
 use crate::argmin::pick_confidence_from_top_k;
 use crate::argmin::{self, AllowedMask, ArgminOffsets, ScoreTransform};
 use crate::error::PredictError;
-use crate::feature_transform::{FeatureTransform, apply_feature_transforms};
+use crate::feature_transform::{
+    FeatureTransform, apply_feature_pipeline_expanding, apply_feature_transforms,
+};
 use crate::inference::forward;
 use crate::model::Model;
 #[cfg(feature = "advanced")]
@@ -39,10 +41,17 @@ pub struct Predictor<'a> {
     #[cfg(feature = "advanced")]
     spec_output: alloc::vec::Vec<OutputValue>,
     /// Scratch buffer for the `_transformed` family. Sized to
-    /// `n_inputs` when the bake declared `feature_transforms`, and
-    /// to zero otherwise (the no-transform path forwards the input
-    /// slice without copying). Reused across calls.
+    /// `n_inputs` when the bake declared scalar-only
+    /// `feature_transforms`, to `model.expanded_input_dim()` when an
+    /// expander variant is present (resized lazily on first call),
+    /// and to zero otherwise (the no-transform path forwards the
+    /// input slice without copying). Reused across calls.
     feat_scratch: alloc::vec::Vec<f32>,
+    /// Scratch view of per-feature param slices, rebuilt on each
+    /// expander-path call. Stored on `Predictor` to avoid an
+    /// allocation per `predict_transformed` invocation; the underlying
+    /// storage lives in `Model::feature_transform_params()`.
+    feat_param_refs: alloc::vec::Vec<&'a [f32]>,
 }
 
 impl<'a> Predictor<'a> {
@@ -72,7 +81,14 @@ impl<'a> Predictor<'a> {
         let need = model.scratch_len();
         let n_out = model.n_outputs();
         let n_in = model.n_inputs();
-        let feat_scratch_len = if model.feature_transforms().is_some() {
+        let feat_scratch_len = if model.has_expander_feature_transforms() {
+            model.expanded_input_dim()
+        } else if model.feature_transforms().is_some() {
+            n_in
+        } else {
+            0
+        };
+        let feat_param_refs_cap = if model.has_expander_feature_transforms() {
             n_in
         } else {
             0
@@ -85,6 +101,7 @@ impl<'a> Predictor<'a> {
             #[cfg(feature = "advanced")]
             spec_output: alloc::vec![OutputValue::Default; n_out],
             feat_scratch: alloc::vec![0.0; feat_scratch_len],
+            feat_param_refs: alloc::vec::Vec::with_capacity(feat_param_refs_cap),
         }
     }
 
@@ -206,41 +223,27 @@ impl<'a> Predictor<'a> {
     pub fn predict_transformed(&mut self, features: &[f32]) -> Result<&[f32], PredictError> {
         // Apply transforms inline so the forward call can borrow
         // `scratch_a`/`scratch_b`/`output` mutably without aliasing
-        // through a helper that also borrows `self`. When the bake
-        // declares parameterized variants (V0_20 ClipThenLog1p /
-        // WinsorP99 / QuantileBins), `apply_with_params` is used
-        // per-feature with the matching slice from
-        // `feature_transform_params`. Non-parameterized features
-        // (Identity / Log* / Signed*) take the empty params path
-        // and behave identically to the no-params call.
-        if let Some(transforms) = self.model.feature_transforms() {
-            if features.len() != transforms.len() {
-                return Err(PredictError::FeatureLenMismatch {
-                    expected: transforms.len(),
-                    got: features.len(),
-                });
-            }
-            if self.feat_scratch.len() < features.len() {
-                self.feat_scratch.resize(features.len(), 0.0);
-            }
-            let dst = &mut self.feat_scratch[..features.len()];
-            match self.model.feature_transform_params() {
-                Some(params) => {
-                    debug_assert_eq!(params.len(), transforms.len());
-                    for i in 0..features.len() {
-                        dst[i] = transforms[i].apply_with_params(features[i], &params[i]);
-                    }
-                }
-                None => apply_feature_transforms(transforms, features, dst)?,
-            }
-            forward(
-                self.model,
-                dst,
-                &mut self.scratch_a,
-                &mut self.scratch_b,
-                &mut self.output,
-            )?;
-        } else {
+        // through a helper that also borrows `self`.
+        //
+        // Three cases, in priority order:
+        //
+        // 1. No transforms metadata ⇒ forward `features` unchanged.
+        //
+        // 2. All transforms are scalar (Identity / Log / Log1p /
+        //    Signed* / Clip* / Winsor* / QuantileBins) ⇒ apply
+        //    per-feature into `feat_scratch[..features.len()]`,
+        //    forward the (raw-length) scratch. Same allocation
+        //    profile as `predict`.
+        //
+        // 3. At least one transform is an expander
+        //    ([`FeatureTransform::Sinusoidal`]) ⇒ allocate
+        //    `feat_scratch` to `model.expanded_input_dim()` slots,
+        //    apply via `apply_feature_pipeline_expanding`, forward
+        //    the expanded scratch. The model's first layer
+        //    `in_dim` must equal `expanded_input_dim()` — this
+        //    is enforced at bake time by the composer, so the
+        //    runtime can trust it.
+        let Some(transforms) = self.model.feature_transforms() else {
             forward(
                 self.model,
                 features,
@@ -248,7 +251,69 @@ impl<'a> Predictor<'a> {
                 &mut self.scratch_b,
                 &mut self.output,
             )?;
+            return Ok(&self.output);
+        };
+        if features.len() != transforms.len() {
+            return Err(PredictError::FeatureLenMismatch {
+                expected: transforms.len(),
+                got: features.len(),
+            });
         }
+
+        let has_expander = self.model.has_expander_feature_transforms();
+        if has_expander {
+            // Expanding path. Per-feature params must be present —
+            // Sinusoidal requires its frequency list.
+            let params = self
+                .model
+                .feature_transform_params()
+                .ok_or(PredictError::UnexpectedExpanderInScalarPipeline { feature_index: 0 })?;
+            let expanded_dim = self.model.expanded_input_dim();
+            if self.feat_scratch.len() < expanded_dim {
+                self.feat_scratch.resize(expanded_dim, 0.0);
+            }
+            let dst = &mut self.feat_scratch[..expanded_dim];
+            // Build a `&[&[f32]]` view over the owned per-feature params.
+            // `feat_param_refs` is a stable scratch field on Predictor;
+            // re-fill it here rather than allocating a fresh Vec.
+            self.feat_param_refs.clear();
+            self.feat_param_refs
+                .extend(params.iter().map(|v| v.as_slice()));
+            apply_feature_pipeline_expanding(transforms, &self.feat_param_refs, features, dst)?;
+            forward(
+                self.model,
+                dst,
+                &mut self.scratch_a,
+                &mut self.scratch_b,
+                &mut self.output,
+            )?;
+            return Ok(&self.output);
+        }
+
+        // Scalar path.
+        if self.feat_scratch.len() < features.len() {
+            self.feat_scratch.resize(features.len(), 0.0);
+        }
+        let dst = &mut self.feat_scratch[..features.len()];
+        match self.model.feature_transform_params() {
+            Some(params) => {
+                debug_assert_eq!(params.len(), transforms.len());
+                for i in 0..features.len() {
+                    // Scalar contract — `apply_with_params` panics for
+                    // expander variants, but `has_expander` already
+                    // proved there aren't any in this branch.
+                    dst[i] = transforms[i].apply_with_params(features[i], &params[i]);
+                }
+            }
+            None => apply_feature_transforms(transforms, features, dst)?,
+        }
+        forward(
+            self.model,
+            dst,
+            &mut self.scratch_a,
+            &mut self.scratch_b,
+            &mut self.output,
+        )?;
         Ok(&self.output)
     }
 

--- a/zenpredict/src/predictor.rs
+++ b/zenpredict/src/predictor.rs
@@ -327,6 +327,12 @@ impl<'a> Predictor<'a> {
         &mut self,
         features: &[f32],
     ) -> Result<&[OutputValue], PredictError> {
+        // Same dispatch as `predict_transformed`: scalar bakes use
+        // the fast path; expander bakes route through
+        // `apply_feature_pipeline_expanding` with an expanded scratch
+        // buffer. The output specs / discrete sets / sparse overrides
+        // post-processing runs once at the bottom regardless of
+        // which pipeline shape filled `self.output`.
         if let Some(transforms) = self.model.feature_transforms() {
             if features.len() != transforms.len() {
                 return Err(PredictError::FeatureLenMismatch {
@@ -334,18 +340,49 @@ impl<'a> Predictor<'a> {
                     got: features.len(),
                 });
             }
-            if self.feat_scratch.len() < features.len() {
-                self.feat_scratch.resize(features.len(), 0.0);
+            if self.model.has_expander_feature_transforms() {
+                let params = self
+                    .model
+                    .feature_transform_params()
+                    .ok_or(PredictError::UnexpectedExpanderInScalarPipeline { feature_index: 0 })?;
+                let expanded_dim = self.model.expanded_input_dim();
+                if self.feat_scratch.len() < expanded_dim {
+                    self.feat_scratch.resize(expanded_dim, 0.0);
+                }
+                let dst = &mut self.feat_scratch[..expanded_dim];
+                self.feat_param_refs.clear();
+                self.feat_param_refs
+                    .extend(params.iter().map(|v| v.as_slice()));
+                apply_feature_pipeline_expanding(transforms, &self.feat_param_refs, features, dst)?;
+                forward(
+                    self.model,
+                    dst,
+                    &mut self.scratch_a,
+                    &mut self.scratch_b,
+                    &mut self.output,
+                )?;
+            } else {
+                if self.feat_scratch.len() < features.len() {
+                    self.feat_scratch.resize(features.len(), 0.0);
+                }
+                let dst = &mut self.feat_scratch[..features.len()];
+                match self.model.feature_transform_params() {
+                    Some(params) => {
+                        debug_assert_eq!(params.len(), transforms.len());
+                        for i in 0..features.len() {
+                            dst[i] = transforms[i].apply_with_params(features[i], &params[i]);
+                        }
+                    }
+                    None => apply_feature_transforms(transforms, features, dst)?,
+                }
+                forward(
+                    self.model,
+                    dst,
+                    &mut self.scratch_a,
+                    &mut self.scratch_b,
+                    &mut self.output,
+                )?;
             }
-            let dst = &mut self.feat_scratch[..features.len()];
-            apply_feature_transforms(transforms, features, dst)?;
-            forward(
-                self.model,
-                dst,
-                &mut self.scratch_a,
-                &mut self.scratch_b,
-                &mut self.output,
-            )?;
         } else {
             forward(
                 self.model,


### PR DESCRIPTION
## Summary

Mirrors the \`predict_transformed\` auto-routing into \`predict_with_specs_transformed\` (gated behind the \`advanced\` feature). Scalar bakes take the fast path; expander bakes route through \`apply_feature_pipeline_expanding\` with \`feat_scratch\` sized to \`model.expanded_input_dim()\`.

Stacked on top of #77 (\`feat/featuretransform-sinusoidal\`) — review-merge order: 77 first, then this one. Both pass the full test suite + clippy clean independently.

## What changed

- \`Predictor::predict_with_specs_transformed\` dispatches on \`model.has_expander_feature_transforms()\`. Same shape as the \`predict_transformed\` dispatch.
- The output specs / discrete sets / sparse overrides post-processing runs once at the bottom regardless of which pipeline filled \`self.output\`.
- New test \`predict_with_specs_transformed_routes_sinusoidal\` bakes a 1-raw-input Sinusoidal-with-2-freqs model (expanded dim 4), feeds x=0, asserts the four outputs are [0, 1, 0, 1] (sin(0), cos(0) per freq) wrapped in \`OutputValue::Override\`.

## Test plan

- [x] 14 tests pass in \`zenpredict-bake/tests/feature_transform.rs\`
- [x] \`cargo clippy -p zenpredict --features advanced\` clean
- [x] No regression in any existing scalar-bake test