### PR TITLE
feat(zenpredict): stable top-K query + zentrain.cell_compute_tier metadata mask helper

### DIFF
--- a/zenpredict-bake/tests/compute_tier.rs
+++ b/zenpredict-bake/tests/compute_tier.rs
@@ -1,0 +1,119 @@
+//! Round-trip the optional `zentrain.cell_compute_tier` metadata key
+//! through bake → load, and verify the generic `tier_mask` masking
+//! helper threads off `Model::cell_compute_tiers`. The
+//! absent-key-is-a-graceful-no-op contract (older bins still load) is
+//! covered too.
+
+#[cfg(test)]
+mod compute_tier_tests {
+    use zenpredict::{
+        Activation, AllowedMask, Model, MetadataType, ScoreTransform, WeightDtype, argmin, keys,
+        tier_mask,
+    };
+    use zenpredict_bake::{BakeLayer, BakeMetadataEntry, BakeRequest, bake};
+
+    #[repr(C, align(16))]
+    struct Aligned(Vec<u8>);
+
+    /// Bake a `n_out`-output identity-ish model, optionally carrying a
+    /// `cell_compute_tier` table (empty `tiers` ⇒ key omitted).
+    fn build_model(n_out: usize, tiers: &[u8]) -> Vec<u8> {
+        // 1 input → n_out outputs, all weights 1.0 so output == input
+        // broadcast; values don't matter for the metadata round-trip.
+        let scaler_mean = [0.0f32];
+        let scaler_scale = [1.0f32];
+        let w = vec![1.0f32; n_out];
+        let b = vec![0.0f32; n_out];
+
+        let mut metadata: Vec<BakeMetadataEntry<'_>> = Vec::new();
+        if !tiers.is_empty() {
+            metadata.push(BakeMetadataEntry {
+                key: keys::CELL_COMPUTE_TIER,
+                // value_type 0 = bytes (hot-path entries must be bytes).
+                kind: MetadataType::Bytes,
+                value: tiers,
+            });
+        }
+
+        let layers = [BakeLayer {
+            in_dim: 1,
+            out_dim: n_out,
+            activation: Activation::Identity,
+            dtype: WeightDtype::F32,
+            weights: &w,
+            biases: &b,
+        }];
+        bake(&BakeRequest {
+            schema_hash: 0,
+            flags: 0,
+            scaler_mean: &scaler_mean,
+            scaler_scale: &scaler_scale,
+            layers: &layers,
+            feature_bounds: &[],
+            metadata: &metadata,
+            output_specs: &[],
+            discrete_sets: &[],
+            sparse_overrides: &[],
+            feature_order: None,
+            output_order: None,
+            compressed: false,
+            hu_permutations: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn cell_compute_tiers_round_trip() {
+        let tiers = [1u8, 3, 2, 9, 1];
+        let bytes = build_model(5, &tiers);
+        let aligned = Aligned(bytes);
+        let model = Model::from_bytes(&aligned.0).unwrap();
+        assert_eq!(model.cell_compute_tiers(), &tiers[..]);
+    }
+
+    #[test]
+    fn absent_tier_table_is_empty_no_op() {
+        // Older-shaped bake with no tier key — accessor returns an
+        // empty slice, not an error, and still loads.
+        let bytes = build_model(3, &[]);
+        let aligned = Aligned(bytes);
+        let model = Model::from_bytes(&aligned.0).unwrap();
+        assert!(model.cell_compute_tiers().is_empty());
+    }
+
+    #[test]
+    fn tier_table_drives_a_fast_only_mask_then_argmin() {
+        // End-to-end: the cheapest-scoring cell is expensive (tier 9);
+        // a tier<=2 budget masks it out, so argmin lands on the
+        // cheapest admissible cell.
+        let tiers = [1u8, 9, 5, 1, 1];
+        let bytes = build_model(5, &tiers);
+        let aligned = Aligned(bytes);
+        let model = Model::from_bytes(&aligned.0).unwrap();
+
+        let model_tiers = model.cell_compute_tiers();
+        assert_eq!(model_tiers, &tiers[..]);
+
+        let scores = [3.0f32, 1.0, 4.0, 1.5, 9.0];
+        let mut gate = vec![false; model_tiers.len()];
+        tier_mask(model_tiers, 2, &mut gate);
+        // tiers = [1, 9, 5, 1, 1], budget <=2 ⇒ idx 1 (9) and idx 2 (5)
+        // masked out.
+        assert_eq!(gate, vec![true, false, false, true, true]);
+
+        let mask = AllowedMask::new(&gate);
+        let pick = argmin::argmin_masked(&scores, &mask, ScoreTransform::Identity, None);
+        // idx 1 (score 1.0) is tier 9 → masked; next-cheapest admissible
+        // is idx 3 (score 1.5, tier 1).
+        assert_eq!(pick, Some(3));
+
+        // And the stable top-K query, also reachable here, returns the
+        // ranked admissible candidates for an encode-verify pass.
+        let top = model
+            .metadata() // touch the model so the borrow is exercised
+            .len();
+        assert!(top >= 1); // tier key is present
+        let topk = argmin::argmin_masked_top_k::<2>(&scores, &mask, ScoreTransform::Identity, None);
+        assert_eq!(topk, [Some(3), Some(0)]); // 1.5 then 3.0
+    }
+}

--- a/zenpredict/CHANGELOG.md
+++ b/zenpredict/CHANGELOG.md
@@ -13,6 +13,32 @@
 
 ### Added
 
+- **New opt-in `topk` feature (default-OFF): stable top-K query + compute-tier
+  mask.** A minimal, stable picker-facing surface — distinct from the unstable
+  `advanced` grab-bag — kept off the default API so the default public surface
+  and default-build monomorphization stay **byte-identical** to a `predict` /
+  `argmin_masked`-only consumer (verified: `cargo public-api` diff on default
+  features is empty vs the prior release; the top-K cost is now opt-in and
+  measurable). Enabled by `--features topk`, and also reachable under `advanced`
+  (each item is gated `cfg(any(topk, advanced))`) for back-compat. Items:
+  - `argmin_masked_top_k::<K>` / `argmin_masked_top_k_in_range::<K>` (free fns)
+    and the matching `Predictor` methods — top-`K` lowest-scoring indices
+    (ascending) for the proven "predict-top-K then encode-verify" picker path
+    (`K = 3` typically). Same masking + score-transform + offsets +
+    NaN/tie-break/mask-length contract as `argmin_masked`.
+  - `keys::CELL_COMPUTE_TIER` (bytes, `[u8; n_outputs]` — one compute-tier rank
+    per output, lower = cheaper), `Model::cell_compute_tiers()` /
+    `Predictor::cell_compute_tiers()` accessors (zero-copy `&[u8]`, empty when
+    absent — older bins still load, a graceful no-op), and the codec-agnostic
+    `argmin::tier_mask(tiers, max_tier, out)` that fills an `AllowedMask` data
+    slice admitting only cells at or below a caller-supplied tier budget, so any
+    codec can mask "fast configs only" without its own per-cell table. Bakers
+    (zentrain) populate the key when tier info is available.
+
+  The closure-scorer (`*_with_scorer`), confidence (`pick_with_confidence*`),
+  and `threshold_mask` variants stay behind `advanced`. `cargo semver-checks`:
+  no update required on the default, `topk`, or `advanced` surface. (571cf1a)
+
 - **Model self-describes its feature provenance** for the `zenanalyze-api`
   offer/reuse contract: three metadata keys `keys::ANALYZER_VERSION` (utf8),
   `keys::FEATURE_DEFS_VERSION` (u32), `keys::FEATURE_CONFIG_HASH` (u64), and

--- a/zenpredict/Cargo.toml
+++ b/zenpredict/Cargo.toml
@@ -23,7 +23,9 @@ exclude = [
 # Render the complete API. The `advanced` typed subsystems are
 # feature-gated; without this docs.rs builds only the default surface
 # and intra-doc links from default items into the gated API break.
-features = ["advanced"]
+# `topk` is gated independently of `advanced` (each item is
+# `cfg(any(topk, advanced))`), so render both to document the full API.
+features = ["topk", "advanced"]
 
 [lib]
 name = "zenpredict"
@@ -35,19 +37,39 @@ default = ["std"]
 # `no_std + alloc` via the unconditional `libm` dependency — no
 # transform degrades when `std` is off.
 std = []
+# STABLE, minimal picker-facing surface (default-OFF). Opt in to the
+# top-K candidate query for the "predict-top-K then encode-verify"
+# picker path plus the compute-tier masking helpers, WITHOUT pulling
+# the unstable `advanced` grab-bag. Gating it (rather than shipping it
+# on the default surface) keeps the default public API + default-build
+# monomorphization byte-identical to a `predict` / `argmin_masked`-only
+# consumer, so the top-K cost stays opt-in and measurable.
+#
+# Items: `argmin_masked_top_k*` (free fns + `Predictor` methods),
+# `tier_mask`, `Model`/`Predictor::cell_compute_tiers`, and the
+# `keys::CELL_COMPUTE_TIER` metadata key. Each is gated
+# `cfg(any(feature = "topk", feature = "advanced"))`, so it's also
+# reachable under `advanced` (back-compat) without `advanced` having
+# to pull `topk`.
+#
+# Unlike `advanced`, this surface follows normal 0.x semver — it does
+# not carry the "may change shape" caveat.
+topk = []
 # Advanced runtime extras for picker pipelines: typed multi-output
 # API (`output_spec::*`, `predict_with_specs*`), bake-time safety
 # metadata reader (`safety::*`), two-shot rescue framework
-# (`rescue::*`), and cached top-K argmin / scorer hybrids
-# (`argmin_masked_top_k*`, `pick_with_confidence*`,
-# `*_with_scorer*`). The wire format parses these sections
+# (`rescue::*`), and the closure-scorer / confidence argmin hybrids
+# (`*_with_scorer*`, `pick_with_confidence*`, `threshold_mask`). The
+# stable `topk` items are ALSO reachable under `advanced` (via their
+# `cfg(any(topk, advanced))` gate) so code that gated on `advanced`
+# keeps compiling. The wire format parses the corresponding sections
 # unconditionally — gating only controls the typed Rust API. Codec
 # runtimes that only call `predict` / `argmin_masked` stay lean by
 # default; per-codec pickers that need the extras opt in.
 #
-# NOT YET STABILIZED: unlike the default surface, items behind
-# `advanced` may change shape or be removed in a 0.2.x patch. Pin a
-# specific version if you depend on them. (Distinct from
+# NOT YET STABILIZED: unlike the default and `topk` surfaces, items
+# behind `advanced` may change shape or be removed in a 0.2.x patch.
+# Pin a specific version if you depend on them. (Distinct from
 # `zenanalyze`'s `experimental`, which gates unstable feature
 # numerics rather than extra API.)
 advanced = []

--- a/zenpredict/README.md
+++ b/zenpredict/README.md
@@ -153,18 +153,25 @@ The `argmin` family is generic — it's "argmin over a slice with a boolean filt
   - `uniform: f32` — added to every cell's score. Same for all cells, so on its own it never changes the pick (e.g. caller-side ICC/EXIF overhead).
   - `per_output: Option<&'a [f32]>` — per-cell additive (e.g. per-config container/ICC bytes). When `Some`, its length **must equal the argmin's working slice** (full `n_outputs` for `argmin_masked`, the sub-range length for `*_in_range`), else `PredictError::OffsetsLenMismatch`. This is the term that can actually shift the pick. Pass `None` (or `ArgminOffsets::uniform(x)` for uniform-only) when you have no per-cell table.
 
-Default-on: `argmin_masked`, `argmin_masked_in_range`.
+Default-on (stable, always compiled): `argmin_masked`, `argmin_masked_in_range`.
 
-Behind the `advanced` feature (default-off): `argmin_masked_top_k*`, `pick_with_confidence*`, `argmin_masked_with_scorer*`, `threshold_mask`, the two-shot `rescue` policy types, `safety::*` accessors, the typed `output_spec` API (`predict_with_specs`, `OutputValue`, `apply_spec`), and the output-space OOD check (`OutputBound`, `output_first_out_of_distribution`). The feature-space OOD check (`FeatureBound`, `first_out_of_distribution`) is default-on. Wire-format slots for `output_specs` / `discrete_sets` / `sparse_overrides` parse unconditionally; the feature gates only the typed Rust API.
+Behind the opt-in **`topk`** feature (default-off, stable — `--features topk`, also reachable under `advanced`): **`argmin_masked_top_k::<K>`** / **`argmin_masked_top_k_in_range::<K>`** (top-`K` lowest-scoring indices, ascending, for the "predict-top-K then encode-verify" picker path — `K = 3` typically) as both free fns and `Predictor` methods, plus **`tier_mask`** + the compute-tier reader (see [Compute-tier masking](#compute-tier-masking)). Kept off the default surface so a `predict` / `argmin_masked`-only consumer pays no extra public API or top-K monomorphization — the cost is opt-in.
+
+Behind the `advanced` feature (default-off): the closure-scorer hybrids `argmin_masked_with_scorer*` / `argmin_masked_top_k_with_scorer*`, `pick_with_confidence*`, `threshold_mask`, the two-shot `rescue` policy types, `safety::*` accessors, the typed `output_spec` API (`predict_with_specs`, `OutputValue`, `apply_spec`), and the output-space OOD check (`OutputBound`, `output_first_out_of_distribution`). `advanced` also re-exposes the whole `topk` surface for back-compat. The feature-space OOD check (`FeatureBound`, `first_out_of_distribution`) is default-on. Wire-format slots for `output_specs` / `discrete_sets` / `sparse_overrides` parse unconditionally; the feature gates only the typed Rust API.
+
+### Compute-tier masking
+
+Behind the opt-in `topk` feature (also reachable under `advanced`). A bake MAY carry an optional `zentrain.cell_compute_tier` metadata key — `[u8; n_outputs]`, one small compute-tier rank per output cell (lower = cheaper to encode; e.g. JXL effort `e1`..`e9`, or any codec's opaque cost rank). `Model::cell_compute_tiers()` (or `Predictor::cell_compute_tiers()`) returns it as a zero-copy `&[u8]`, **empty** when the bake omits it — so older bins still load and the caller just skips tier masking. The generic `argmin::tier_mask(tiers, max_tier, out)` fills a `&mut [bool]` admitting only cells whose tier is `<= max_tier`; AND it into your constraint mask before `argmin_masked` / `argmin_masked_top_k` to express "fast configs only" under a time budget, with no per-codec tier table.
 
 ## Features
 
 | Feature | Default | What it gates |
 |---|---|---|
 | `std` | yes | `std::error::Error` trait impls |
-| `advanced` | no | safety / rescue / output_specs typed API / top-K argmin + scorer hybrids — see "Decision math" above |
+| `topk` | no | **stable, minimal** picker surface: top-`K` argmin query (`argmin_masked_top_k*`, free fns + `Predictor` methods) + compute-tier masking (`tier_mask`, `Model`/`Predictor::cell_compute_tiers`, `keys::CELL_COMPUTE_TIER`) — see "Decision math" above |
+| `advanced` | no | safety / rescue / output_specs typed API / closure-scorer argmin hybrids / `pick_with_confidence` / `threshold_mask` — see "Decision math" above. Also re-exposes the `topk` surface for back-compat. |
 
-The `advanced` surface is **not yet stabilized** — items behind it may change shape or be removed in a 0.2.x patch, so pin a version if you depend on them. The default surface follows normal 0.x semver. (`advanced` gates extra API; it's a different axis from `zenanalyze`'s `experimental`, which gates unstable feature numerics.)
+The default surface and the `topk` surface follow normal 0.x semver (and the default surface stays byte-identical to a `predict`-only consumer — enabling `topk` is the only way to add the top-K API + its compile cost). The `advanced` surface is **not yet stabilized** — items behind it may change shape or be removed in a 0.2.x patch, so pin a version if you depend on them. (`advanced` gates extra API; it's a different axis from `zenanalyze`'s `experimental`, which gates unstable feature numerics.)
 
 `no_std + alloc` builds drop only the `std::error::Error` impls. All numeric work — including `f32::exp` for `ScoreTransform::Exp` — runs identically via the unconditional `libm` dependency.
 

--- a/zenpredict/src/argmin.rs
+++ b/zenpredict/src/argmin.rs
@@ -194,11 +194,39 @@ pub fn argmin_masked(
 /// permits, ascending (best first). Slots beyond the number of
 /// allowed entries are `None`. `K` is generic to keep the call
 /// site allocation-free; in practice `K = 2` is what codec rescue
-/// logic wants (cached second-best).
+/// logic wants (cached second-best), and `K = 3` is what the
+/// "predict-top-K then encode-verify" picker path wants.
+///
+/// Behind the opt-in `topk` feature (also reachable under
+/// `advanced`) — a stable, minimal picker-facing surface kept off
+/// the default API so the default build's public surface and
+/// monomorphization stay byte-identical to a `predict` /
+/// `argmin_masked`-only consumer. Same support guarantee as
+/// [`argmin_masked`], so a per-codec picker or [`zenpicker`] can
+/// request the top-K candidate output indices (same masking,
+/// score-transform, and range options). The closure-scorer variants
+/// `*_with_scorer`, the confidence helpers, and `threshold_mask` stay
+/// behind `advanced`.
 ///
 /// Same NaN, tie-breaking, and mask-length contract as
 /// [`argmin_masked`].
-#[cfg(feature = "advanced")]
+///
+/// [`zenpicker`]: https://docs.rs/zenpicker
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(any(feature = "topk", feature = "advanced"))] {
+/// use zenpredict::{AllowedMask, ScoreTransform, argmin};
+///
+/// let scores = [3.0_f32, 1.0, 4.0, 1.5, 9.0];
+/// let mask_data = [true; 5];
+/// let mask = AllowedMask::new(&mask_data);
+/// let top = argmin::argmin_masked_top_k::<3>(&scores, &mask, ScoreTransform::Identity, None);
+/// assert_eq!(top, [Some(1), Some(3), Some(0)]); // 1.0, 1.5, 3.0
+/// # }
+/// ```
+#[cfg(any(feature = "topk", feature = "advanced"))]
 pub fn argmin_masked_top_k<const K: usize>(
     predictions: &[f32],
     mask: &AllowedMask<'_>,
@@ -263,7 +291,17 @@ pub fn argmin_masked_in_range(
     let slice = predictions.get(start..end)?;
     argmin_masked(slice, mask, transform, offsets)
 }
-#[cfg(feature = "advanced")]
+
+/// Top-`K` over a sub-range `predictions[range.0..range.1]`, masked
+/// by `mask` (whose `len()` must be `>= range.1 - range.0`).
+/// Returned indices are *within the sub-range*. Behind the opt-in
+/// `topk` feature (also reachable under `advanced`) — same support
+/// guarantee as [`argmin_masked_top_k`].
+///
+/// Returns all-`None` when the range is out of bounds (`end >
+/// predictions.len()` or `start > end`) — the in-range argmin
+/// scalar form returns `None` on the same condition.
+#[cfg(any(feature = "topk", feature = "advanced"))]
 pub fn argmin_masked_top_k_in_range<const K: usize>(
     predictions: &[f32],
     range: (usize, usize),
@@ -276,6 +314,58 @@ pub fn argmin_masked_top_k_in_range<const K: usize>(
         return [None; K];
     }
     argmin_masked_top_k::<K>(&predictions[start..end], mask, transform, offsets)
+}
+
+/// Fill `out[i] = tiers[i] <= max_tier` — an [`AllowedMask`] data
+/// slice that admits only output cells whose compute-tier rank is at
+/// most `max_tier`, masking out everything more expensive.
+///
+/// Behind the opt-in `topk` feature (also reachable under
+/// `advanced`). Generic and codec-agnostic: pair it with a bake's
+/// [`zentrain.cell_compute_tier`](crate::keys::CELL_COMPUTE_TIER)
+/// table ([`Model::cell_compute_tiers`]) so any codec can express
+/// "fast configs only" under a caller-supplied time budget without
+/// shipping its own per-cell tier table. AND the result into the
+/// codec's constraint mask before calling [`argmin_masked`] /
+/// [`argmin_masked_top_k`].
+///
+/// `out.len()` must equal `tiers.len()`; mismatched lengths **panic**
+/// in debug and release (same discipline as [`AllowedMask`]'s
+/// length contract — a short `out` would silently admit the
+/// unwritten tail).
+///
+/// Absent tier metadata is a graceful no-op at the call site: when
+/// [`Model::cell_compute_tiers`] returns an empty slice, skip the
+/// AND entirely (admit every cell). This helper is only invoked when
+/// a tier table is actually present.
+///
+/// [`Model::cell_compute_tiers`]: crate::Model::cell_compute_tiers
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(any(feature = "topk", feature = "advanced"))] {
+/// use zenpredict::argmin::tier_mask;
+///
+/// // Per-cell compute tiers (e.g. JXL effort e1..e3 → 1,2,3).
+/// let tiers = [1_u8, 3, 2, 3, 1];
+/// let mut gate = [false; 5];
+/// tier_mask(&tiers, 2, &mut gate); // admit tiers <= 2
+/// assert_eq!(gate, [true, false, true, false, true]);
+/// # }
+/// ```
+#[cfg(any(feature = "topk", feature = "advanced"))]
+pub fn tier_mask(tiers: &[u8], max_tier: u8, out: &mut [bool]) {
+    assert_eq!(
+        tiers.len(),
+        out.len(),
+        "tier_mask: tiers.len() ({}) != out.len() ({})",
+        tiers.len(),
+        out.len(),
+    );
+    for (slot, &t) in out.iter_mut().zip(tiers.iter()) {
+        *slot = t <= max_tier;
+    }
 }
 
 /// Argmin under a caller-supplied score function. `scorer(i)` is

--- a/zenpredict/src/lib.rs
+++ b/zenpredict/src/lib.rs
@@ -145,10 +145,16 @@ pub mod wire;
 pub use argmin::{
     AllowedMask, ArgminOffsets, ScoreTransform, argmin_masked, argmin_masked_in_range,
 };
+// Stable, minimal picker-facing surface — opt-in via `topk` (also
+// reachable under `advanced`). Kept off the default re-export so the
+// default public API stays byte-identical to a `predict` /
+// `argmin_masked`-only consumer.
+#[cfg(any(feature = "topk", feature = "advanced"))]
+pub use argmin::{argmin_masked_top_k, argmin_masked_top_k_in_range, tier_mask};
 #[cfg(feature = "advanced")]
 pub use argmin::{
-    argmin_masked_top_k, argmin_masked_top_k_in_range, argmin_masked_top_k_with_scorer,
-    argmin_masked_with_scorer, pick_with_confidence, pick_with_confidence_in_range, threshold_mask,
+    argmin_masked_top_k_with_scorer, argmin_masked_with_scorer, pick_with_confidence,
+    pick_with_confidence_in_range, threshold_mask,
 };
 pub use bounds::{FeatureBound, first_out_of_distribution};
 #[cfg(feature = "advanced")]

--- a/zenpredict/src/metadata.rs
+++ b/zenpredict/src/metadata.rs
@@ -400,6 +400,29 @@ pub mod keys {
     /// within-major drift the name-based schema hash can't (a feature keeping its
     /// name while its math moves). Absent on models baked before this key.
     pub const FEATURE_DEFS_VERSION: &str = "zentrain.feature_defs_version";
+    /// bytes — `[u8; n_outputs]`, one small compute-tier rank per
+    /// output index (the codec config that output cell encodes).
+    /// Lower = cheaper/faster; higher = more CPU (e.g. for JXL,
+    /// effort `e1`..`e9`; for any codec, an opaque cost rank the
+    /// bake assigns). Lets a runtime mask out "too expensive"
+    /// configs under a caller-supplied time budget WITHOUT each
+    /// codec shipping its own per-cell tier table — see
+    /// [`crate::Model::cell_compute_tiers`] and the generic
+    /// [`crate::argmin::tier_mask`] helper.
+    ///
+    /// Optional: bakers omit the key entirely when they have no
+    /// tier information, and the runtime treats absence as a no-op
+    /// (all cells admitted, no masking) so older bins still load.
+    /// Decoded as raw bytes (one `u8` per output), so it round-trips
+    /// identically on every target.
+    ///
+    /// Behind the opt-in `topk` feature (also reachable under
+    /// `advanced`), alongside its reader
+    /// [`crate::Model::cell_compute_tiers`] and the
+    /// [`crate::argmin::tier_mask`] helper.
+    #[cfg(any(feature = "topk", feature = "advanced"))]
+    pub const CELL_COMPUTE_TIER: &str = "zentrain.cell_compute_tier";
+
     /// numeric (u64) — `zenanalyze::AnalysisQuery::config_hash()` at bake time:
     /// the value-affecting analysis-config digest the model was trained under
     /// (`0` = canonical default / gamma). The third part of the `zenanalyze-api`

--- a/zenpredict/src/model.rs
+++ b/zenpredict/src/model.rs
@@ -901,6 +901,47 @@ impl Model {
         Some(u64::from_le_bytes(arr))
     }
 
+    /// Per-output compute-tier ranks from the
+    /// [`CELL_COMPUTE_TIER`](crate::keys::CELL_COMPUTE_TIER) metadata
+    /// key: one small `u8` per output index (the codec config that
+    /// output cell encodes), lower = cheaper. Empty slice when the
+    /// key is absent (older bakes) — a graceful no-op, so a caller
+    /// can `if !tiers.is_empty()` and skip tier masking entirely. The
+    /// per-output length (`== n_outputs`) is the bake's contract; this
+    /// accessor returns whatever bytes the key carries.
+    ///
+    /// Pair with the generic [`crate::argmin::tier_mask`] helper to
+    /// build an [`crate::AllowedMask`] data slice that admits only
+    /// "fast enough" cells under a caller-supplied budget, without
+    /// the codec maintaining its own tier table.
+    ///
+    /// Zero-copy: the returned slice borrows the model's backing
+    /// bytes. One `u8` per output, so no alignment / endianness
+    /// concerns.
+    ///
+    /// Behind the opt-in `topk` feature (also reachable under
+    /// `advanced`).
+    #[cfg(any(feature = "topk", feature = "advanced"))]
+    pub fn cell_compute_tiers(&self) -> &[u8] {
+        let raw = self
+            .header
+            .metadata
+            .slice("metadata", &self.bytes)
+            .expect("metadata validated at parse time");
+        // Re-walk the (small, ≤30-entry) blob for the one key. Each
+        // `MetadataEntry.value` borrows `raw` (== `&self.bytes`), not
+        // the temporary `Metadata` Vec, so copying the `&[u8]` field
+        // out detaches it from the `Metadata`'s lifetime and lets it
+        // outlive the `match`. Any byte length is a valid `[u8; N]`,
+        // so there's no wrong-width rejection — the per-output length
+        // (== n_outputs) is the caller's contract.
+        Metadata::parse(raw)
+            .expect("metadata blob parse validated at parse time")
+            .get(crate::keys::CELL_COMPUTE_TIER)
+            .map(|entry| entry.value)
+            .unwrap_or(&[])
+    }
+
     /// Per-output [`OutputSpec`] table.
     pub fn output_specs(&self) -> &[OutputSpec] {
         if self.header.output_specs.is_empty() {

--- a/zenpredict/src/predictor.rs
+++ b/zenpredict/src/predictor.rs
@@ -426,6 +426,23 @@ impl<'a> Predictor<'a> {
         self.model.feature_transforms()
     }
 
+    /// Per-output compute-tier ranks declared by the bake (the
+    /// [`CELL_COMPUTE_TIER`](crate::keys::CELL_COMPUTE_TIER)
+    /// metadata). Convenience re-export of
+    /// [`Model::cell_compute_tiers`] so callers holding a `Predictor`
+    /// don't need to thread the model through. Empty slice when the
+    /// bake carries no tier table (graceful no-op).
+    ///
+    /// Behind the opt-in `topk` feature (also reachable under
+    /// `advanced`). Feed into [`crate::argmin::tier_mask`] to build a
+    /// "fast configs only" mask under a caller-supplied budget.
+    ///
+    /// [`Model::cell_compute_tiers`]: crate::Model::cell_compute_tiers
+    #[cfg(any(feature = "topk", feature = "advanced"))]
+    pub fn cell_compute_tiers(&self) -> &[u8] {
+        self.model.cell_compute_tiers()
+    }
+
     /// Pick the argmin output index over the masked set.
     pub fn argmin_masked(
         &mut self,
@@ -477,7 +494,18 @@ impl<'a> Predictor<'a> {
         ))
     }
 
-    #[cfg(feature = "advanced")]
+    /// Run the forward pass, then return the top-`K` lowest-scoring
+    /// output indices the `mask` permits, ascending (best first).
+    /// Slots beyond the number of mask-allowed entries are `None`.
+    ///
+    /// Behind the opt-in `topk` feature (also reachable under
+    /// `advanced`) — a stable, minimal picker-facing surface, so a
+    /// per-codec picker or `zenpicker` can run the proven
+    /// "predict-top-K then encode-verify" path (`K = 3` typically) at
+    /// runtime. Same masking + score-transform + offsets options as
+    /// [`Self::argmin_masked`]; same NaN / tie-break / mask-length
+    /// contract as [`argmin::argmin_masked_top_k`].
+    #[cfg(any(feature = "topk", feature = "advanced"))]
     pub fn argmin_masked_top_k<const K: usize>(
         &mut self,
         features: &[f32],
@@ -497,7 +525,12 @@ impl<'a> Predictor<'a> {
         ))
     }
 
-    #[cfg(feature = "advanced")]
+    /// Top-`K` over a sub-range of the output vector (hybrid-heads
+    /// layout — see [`Self::argmin_masked_in_range`]). Returned
+    /// indices are within the sub-range. Behind the opt-in `topk`
+    /// feature (also reachable under `advanced`) — same support
+    /// guarantee as [`Self::argmin_masked_top_k`].
+    #[cfg(any(feature = "topk", feature = "advanced"))]
     pub fn argmin_masked_top_k_in_range<const K: usize>(
         &mut self,
         features: &[f32],

--- a/zenpredict/src/tests.rs
+++ b/zenpredict/src/tests.rs
@@ -122,6 +122,170 @@ fn metadata_empty_blob_yields_empty() {
     assert!(m.is_empty());
 }
 
+// --- Opt-in `topk` surface: top-K query + compute-tier masking ---
+//
+// Gated behind `any(topk, advanced)` so they run under BOTH
+// `--features topk` and the `advanced` superset, and stay off the
+// default build. The whole point of the gate is that the default
+// public API + monomorphization match a `predict` / `argmin_masked`-
+// only consumer; these tests therefore only exist when the feature
+// that adds the surface is enabled.
+#[cfg(any(feature = "topk", feature = "advanced"))]
+mod topk_surface {
+    use super::*;
+
+    #[test]
+    fn stable_top_k_sorted_indices() {
+        let pred = [3.0f32, 1.0, 4.0, 1.5, 9.0];
+        let mask = [true; 5];
+        let m = AllowedMask::new(&mask);
+        // Free function.
+        let top = argmin::argmin_masked_top_k::<3>(&pred, &m, ScoreTransform::Identity, None);
+        assert_eq!(top, [Some(1), Some(3), Some(0)]);
+        // Re-exported at crate root under the same gate.
+        let top2 = crate::argmin_masked_top_k::<2>(&pred, &m, ScoreTransform::Identity, None);
+        assert_eq!(top2, [Some(1), Some(3)]);
+    }
+
+    #[test]
+    fn stable_top_k_respects_mask_and_fills_none() {
+        // Only 2 cells allowed but K=3 ⇒ third slot is None.
+        let pred = [3.0f32, 1.0, 4.0, 1.5, 9.0];
+        let mask = [false, true, false, true, false];
+        let m = AllowedMask::new(&mask);
+        let top = argmin::argmin_masked_top_k::<3>(&pred, &m, ScoreTransform::Identity, None);
+        assert_eq!(top, [Some(1), Some(3), None]);
+    }
+
+    #[test]
+    fn stable_top_k_in_range_indices_are_local() {
+        // Sub-range [2..5] of the output; returned indices are within
+        // the sub-range (0..3), not absolute.
+        let pred = [9.0f32, 9.0, 4.0, 1.5, 3.0];
+        let mask = [true; 3];
+        let m = AllowedMask::new(&mask);
+        let top = argmin::argmin_masked_top_k_in_range::<2>(
+            &pred,
+            (2, 5),
+            &m,
+            ScoreTransform::Identity,
+            None,
+        );
+        // sub-slice = [4.0, 1.5, 3.0] ⇒ argmin order 1 (1.5), 2 (3.0).
+        assert_eq!(top, [Some(1), Some(2)]);
+    }
+
+    #[test]
+    fn stable_top_k_in_range_out_of_bounds_all_none() {
+        let pred = [1.0f32, 2.0, 3.0];
+        let mask = [true; 2];
+        let m = AllowedMask::new(&mask);
+        let top = argmin::argmin_masked_top_k_in_range::<2>(
+            &pred,
+            (2, 9), // end > len
+            &m,
+            ScoreTransform::Identity,
+            None,
+        );
+        assert_eq!(top, [None, None]);
+    }
+
+    // --- tier_mask (compute-tier masking helper) ---
+
+    #[test]
+    fn tier_mask_admits_at_or_below_max() {
+        // Boundary: tier == max_tier is ADMITTED.
+        let tiers = [1u8, 3, 2, 3, 1];
+        let mut out = [false; 5];
+        crate::tier_mask(&tiers, 2, &mut out);
+        assert_eq!(out, [true, false, true, false, true]);
+    }
+
+    #[test]
+    fn tier_mask_zero_admits_only_cheapest() {
+        let tiers = [0u8, 1, 0, 2];
+        let mut out = [false; 4];
+        crate::tier_mask(&tiers, 0, &mut out);
+        assert_eq!(out, [true, false, true, false]);
+    }
+
+    #[test]
+    fn tier_mask_high_max_admits_all() {
+        let tiers = [0u8, 5, 9, 255];
+        let mut out = [false; 4];
+        crate::tier_mask(&tiers, 255, &mut out);
+        assert_eq!(out, [true; 4]);
+    }
+
+    #[test]
+    #[should_panic(expected = "tier_mask")]
+    fn tier_mask_length_mismatch_panics() {
+        let tiers = [1u8, 2, 3];
+        let mut out = [false; 2]; // len 2 != 3
+        crate::tier_mask(&tiers, 1, &mut out);
+    }
+
+    #[test]
+    fn tier_mask_then_argmin_picks_cheapest_good() {
+        // End-to-end shape: scores favor an expensive cell (idx 1,
+        // score 1.0, tier 9) but the tier gate masks it out, so argmin
+        // lands on the cheapest admissible cell (idx 3, score 1.5,
+        // tier 1).
+        let scores = [3.0f32, 1.0, 4.0, 1.5, 9.0];
+        let tiers = [1u8, 9, 5, 1, 1];
+        let mut gate = [false; 5];
+        crate::tier_mask(&tiers, 2, &mut gate); // admit tiers <= 2
+        let m = AllowedMask::new(&gate);
+        let pick = argmin::argmin_masked(&scores, &m, ScoreTransform::Identity, None);
+        assert_eq!(pick, Some(3));
+    }
+
+    // --- CELL_COMPUTE_TIER metadata key parses off the blob wire form ---
+    //
+    // `Model::cell_compute_tiers` is round-trip-tested through the bake
+    // crate (`zenpredict-bake/tests/compute_tier.rs`); here we exercise
+    // the underlying metadata-blob read it relies on, plus the
+    // absent-key graceful-no-op contract.
+
+    /// Encode one metadata entry in the v3 blob wire form:
+    /// `key_len u8 | key | value_type u8 | value_len u32 LE | value`.
+    fn push_md_entry(blob: &mut alloc::vec::Vec<u8>, key: &str, value_type: u8, value: &[u8]) {
+        blob.push(key.len() as u8);
+        blob.extend_from_slice(key.as_bytes());
+        blob.push(value_type);
+        blob.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        blob.extend_from_slice(value);
+    }
+
+    #[test]
+    fn cell_compute_tier_key_round_trips_in_blob() {
+        let tiers = [1u8, 3, 2, 9];
+        let mut blob = alloc::vec::Vec::new();
+        // value_type 0 = bytes (hot-path entries must be bytes, per the
+        // metadata module contract).
+        push_md_entry(&mut blob, keys::CELL_COMPUTE_TIER, 0, &tiers);
+        let md = Metadata::parse(&blob).unwrap();
+        let entry = md.get(keys::CELL_COMPUTE_TIER).expect("tier key present");
+        assert_eq!(entry.value, &tiers[..]);
+
+        // And it threads straight into the masking helper.
+        let mut gate = [false; 4];
+        crate::tier_mask(entry.value, 2, &mut gate);
+        assert_eq!(gate, [true, false, true, false]);
+    }
+
+    #[test]
+    fn cell_compute_tier_absent_is_graceful() {
+        // A blob with a different key → looking up the tier key yields
+        // None (which `Model::cell_compute_tiers` maps to an empty
+        // slice).
+        let mut blob = alloc::vec::Vec::new();
+        push_md_entry(&mut blob, keys::BAKE_NAME, 1, b"some_picker_v1");
+        let md = Metadata::parse(&blob).unwrap();
+        assert!(md.get(keys::CELL_COMPUTE_TIER).is_none());
+    }
+}
+
 #[test]
 fn argmin_nan_score_is_silently_skipped() {
     // NaN never compares less than a finite value, so a cell with


### PR DESCRIPTION
## What

Two **additive, opt-in** capabilities for `zenpredict` (the zero-copy ZNPR v3 runtime), gated behind a **new default-OFF `topk` Cargo feature** so per-codec pickers and `zenpicker` can reach them at runtime **without** touching the default surface or the unstable `advanced` grab-bag. zenpredict is API-frozen at its leading version digit (`0.2.x`); these are new/optional items only.

**The default public API + default-build compile are byte-identical to `main`** (verified — see below). Enabling `topk` is the only way to add the top-K API and its monomorphization cost, so both stay opt-in and measurable.

### 1. Stable top-K query (the "predict-top-K then encode-verify" path)

`argmin_masked_top_k::<K>` / `argmin_masked_top_k_in_range::<K>` (free functions) and the matching `Predictor::argmin_masked_top_k::<K>` / `argmin_masked_top_k_in_range::<K>` methods, behind `topk`. Per-codec pickers / `zenpicker` request the top-K candidate output indices (`K = 3` typically) to drive the ≤1% encode-verify rescue path, with the **same masking + score-transform + offsets + NaN / tie-break / mask-length contract** as `argmin_masked`.

### 2. Optional `zentrain.cell_compute_tier` metadata + generic tier mask

So effort/CPU masking is no longer hardcoded per codec:

- `keys::CELL_COMPUTE_TIER` — bytes, `[u8; n_outputs]`, one compute-tier rank per output (lower = cheaper; e.g. JXL effort `e1..e9`). **Optional**: bakers omit it when there's no tier info.
- `Model::cell_compute_tiers()` / `Predictor::cell_compute_tiers()` — zero-copy `&[u8]`, **empty when absent** so older bins still load (graceful no-op).
- `argmin::tier_mask(tiers, max_tier, out)` — generic; fills an `AllowedMask` data slice admitting only cells at/below a budget. "Fast configs only" under a time budget, **without each codec shipping its own per-cell tier table**.

## Feature gating

- **New `topk = []` feature** (default-OFF): stable, minimal picker surface.
- All new items are `#[cfg(any(feature = "topk", feature = "advanced"))]` — reachable via `--features topk` **or** `advanced` (back-compat). NOT in the default re-export.
- The closure-scorer (`argmin_masked*_with_scorer*`), `pick_with_confidence*`, and `threshold_mask` variants **stay behind `advanced`** as before.

## New public API (opt-in via `topk`; also under `advanced`)

```rust
// argmin (free fns)
pub fn argmin_masked_top_k<const K: usize>(predictions: &[f32], mask: &AllowedMask<'_>,
    transform: ScoreTransform, offsets: Option<&ArgminOffsets<'_>>) -> [Option<usize>; K]
pub fn argmin_masked_top_k_in_range<const K: usize>(predictions: &[f32], range: (usize, usize),
    mask: &AllowedMask<'_>, transform: ScoreTransform, offsets: Option<&ArgminOffsets<'_>>) -> [Option<usize>; K]
pub fn tier_mask(tiers: &[u8], max_tier: u8, out: &mut [bool])

// Predictor methods
pub fn argmin_masked_top_k<const K: usize>(&mut self, features: &[f32], mask: &AllowedMask<'_>,
    transform: ScoreTransform, offsets: Option<&ArgminOffsets<'_>>) -> Result<[Option<usize>; K], PredictError>
pub fn argmin_masked_top_k_in_range<const K: usize>(&mut self, features: &[f32], range: (usize, usize),
    mask: &AllowedMask<'_>, transform: ScoreTransform, offsets: Option<&ArgminOffsets<'_>>) -> Result<[Option<usize>; K], PredictError>

// Predictor / Model
pub fn cell_compute_tiers(&self) -> &[u8]          // on both Predictor and Model

// metadata key
pub const keys::CELL_COMPUTE_TIER: &str = "zentrain.cell_compute_tier";
```

## Verification (all via `run-heavy --jobs 6`)

- **`cargo public-api` diff on DEFAULT features vs `main`: EMPTY** — 1388 vs 1388 API lines, zero change. `topk` adds exactly the 11 expected lines and nothing else; `advanced` gains only the 5 new tier items (additively — top-K already existed under `advanced` on `main`, no removals).
- **`cargo semver-checks` (baseline `main`): no update required** on the **default, `topk`, and `advanced`** surfaces (196 checks pass each). No leading-digit bump; next release is a `0.2.x` patch.
- New unit tests in a `#[cfg(any(topk, advanced))]` module (run under `--features topk` and all-features; absent on default): stable top-K (sorted / masked / in-range / OOB), `tier_mask` (boundary / panic-on-length-mismatch / argmin integration), and `CELL_COMPUTE_TIER` blob parse + absent-key no-op.
- `Model::cell_compute_tiers()` round-trips via `zenpredict-bake/tests/compute_tier.rs` (bake → load → tier_mask → argmin), reachable through the bake crate's `advanced` dev-dep.
- Tests: default **73** / `topk` **84** / all-features **99** + doctests green. Full `zenpredict-bake` suite green. Clippy clean (default / topk / all-features). Whole `zenanalyze` workspace builds.
- README + CHANGELOG updated to the "opt-in `topk` feature" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
